### PR TITLE
Modified indexing method for SimulationResult

### DIFF
--- a/docs/source/emulator/analyzer.rst
+++ b/docs/source/emulator/analyzer.rst
@@ -81,7 +81,7 @@ The results from can then be plotted to view the transformation. The returned :d
     plot_array = np.zeros((len(inputs), len(inputs)))
     for i, istate in enumerate(inputs.values()):
         for j, ostate in enumerate(inputs.values()):
-            plot_array[i,j] = results[istate:ostate]
+            plot_array[i,j] = results[istate, ostate]
 
     in_labels = list(inputs.keys())
     out_labels = in_labels

--- a/docs/source/emulator/simulator.rst
+++ b/docs/source/emulator/simulator.rst
@@ -30,7 +30,10 @@ The Simulator can then be created, this requires the created circuit from above.
 
     sim = emulator.Simulator(circuit)
 
-To retrieve probability amplitudes from the system the ``simulate`` method should then be used. At minimum, this requires the input(s) are specified and the target outputs cannot be specified. If the target outputs are not specified, then all possible outputs with photon number matching the input photon number will be calculated. This introduces the condition that all inputs and outputs provided by a user must have the same photon number, if this is not the case then two separate calls to simulate must be made.
+Simulation
+----------
+
+To retrieve probability amplitudes from the system the ``simulate`` method should then be used. At minimum, this requires the input(s) are specified, and optionally target outputs may also be specified. If the target outputs are not included, then all possible outputs with photon number matching the input photon number will be calculated. This introduces the condition that all inputs and outputs provided by a user must have the same photon number, if this is not the case then two separate calls to simulate must be made. When specifying a single input/output it is possible to provide these as States, but for multiple inputs and outputs then these are provided as lists. 
 
 To find the probability amplitude between then input :math:`\ket{1,1,0,0}` and output :math:`\ket{0,0,1,1}`, the code required would therefore be:
 
@@ -41,7 +44,17 @@ To find the probability amplitude between then input :math:`\ket{1,1,0,0}` and o
 
     results = sim.simulate(input_state, output_state)
 
-This will return a :doc:`../emulator_reference/simulation_result` object, the raw data of which can be accessed with the array attribute.
+This will return a :doc:`../emulator_reference/simulation_result` object. We can access data for specific input and outputs using the ``[]`` operator on the object. The behaviour of this slightly varies depending on whether the simulation used one or multiple inputs. In the single input case it is possible to do ``[output_state]`` to get the value for a particular output, whereas for multiple inputs ``[input_state]`` will return all possible outputs for an input and ``[input_state:output_state]`` will produce a singular value for the selected combination. As only one input was used above the following are therefore equivalent:
+
+.. code-block:: Python
+
+    print(results[output_state])
+    # Output: (0.037523401912278494-0.25889120714091474j)
+
+    print(results[input_state, output_state])
+    # Output: (0.037523401912278494-0.25889120714091474j)
+
+Alternatively, the raw data of the results can be accessed with the array attribute.
 
 .. code-block:: Python
 

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -104,7 +104,7 @@ class SimulationResult:
         """
         return self.__result_type
     
-    def __getitem__(self, item: State | slice) -> float | dict:
+    def __getitem__(self, item: State | tuple) -> float | dict:
         """Custom get item behaviour - used when object accessed with []."""
         if isinstance(item, State):
             # When only one input is used, automatically return output value
@@ -119,36 +119,37 @@ class SimulationResult:
                     return self.dictionary[item]
                 else:
                     raise KeyError("Provided input state not in data.")
-        elif isinstance(item, slice):
-            # Separate slice into two states
-            istate = item.start
-            ostate = item.stop
-            # For : slice return all data, unless a single input is present in 
-            # which case just return that
-            if istate is None and ostate is None:
-                if len(self.inputs) == 1:
-                    return self.dictionary[self.inputs[0]]
-                else:
-                    return self.dictionary
+        elif isinstance(item, tuple):
+            # Check only two values have been provided
+            if len(item) > 2:
+                raise ValueError(
+                    "Get item can only contain a maximum of two values.")
+            # Separate data into two states
+            istate = item[0]
+            ostate = item[1]
             # Check all aspects are valid
             if (not isinstance(istate, State) or 
                 not isinstance(ostate, (State, type(None)))):
                 raise ValueError(
-                    "Items used in slices should have type State.")
+                    "Get item values should have type State.")
             if istate in self.dictionary:
                 sub_r = self.dictionary[istate]
             else:
-                raise KeyError("Provided input state not in data.")
-            # If open ended slice used then return all results for input
+                raise KeyError("Requested input state not in data.")
+            # If None provided as second value then return all results for input
             if ostate is None:
                 return sub_r
             # Else return requested value
             elif ostate in sub_r:
                 return sub_r[ostate]
             else:
-                raise KeyError("Provided output State not in data.")
+                raise KeyError("Requested output state not in data.")
+        elif isinstance(item, slice):
+            raise DeprecationWarning(
+                "Retrieval of data through slicing is no longer supported.")
         else:
-            raise ValueError("Get item value must be a State or slice.")
+            raise ValueError(
+                "Get item value must be either one or two States.")
         
     def __str__(self) -> str:
         return str(self.dictionary)

--- a/tests/emulator/result_test.py
+++ b/tests/emulator/result_test.py
@@ -114,19 +114,15 @@ class TestSimulationResult:
                                        State([0,1,0,1]): 0.2, 
                                        State([0,0,2,0]): 0.1}
         
-    def test_result_slicing(self):
+    def test_result_indexing(self):
         """
         Confirms that result retrieval works correctly for multi input case,
-        with slicing used to specify the input and output.
+        with both the input and output used to get a single value.
         """
         r = SimulationResult(self.test_array, "probability_amplitude", 
                              inputs = self.test_inputs, 
                              outputs = self.test_outputs)
-        assert r[State([1,1,0,0]):State([0,0,2,0])] == 0.1
-        # Also check open ended slicing
-        assert r[State([1,1,0,0]):] == {State([1,0,1,0]): 0.3, 
-                                        State([0,1,0,1]): 0.2, 
-                                        State([0,0,2,0]): 0.1}
+        assert r[State([1,1,0,0]), State([0,0,2,0])] == 0.1
             
     def test_multi_input_plot(self):
         """

--- a/tests/sdk/qubit_gate_test.py
+++ b/tests/sdk/qubit_gate_test.py
@@ -108,10 +108,10 @@ class TestTwoQubitGates:
         sim = Simulator(CZ())
         results = sim.simulate(states, states)
         # Check all results are identical except for |1,1> which has a -1
-        amp = results[states[0]:states[0]]
-        assert pytest.approx(amp, 1e-6) == results[states[1]:states[1]]
-        assert pytest.approx(amp, 1e-6) == results[states[2]:states[2]]
-        assert pytest.approx(amp, 1e-6) == -results[states[3]:states[3]]
+        amp = results[states[0], states[0]]
+        assert pytest.approx(amp, 1e-6) == results[states[1], states[1]]
+        assert pytest.approx(amp, 1e-6) == results[states[2], states[2]]
+        assert pytest.approx(amp, 1e-6) == -results[states[3], states[3]]
         # Confirm success probability is 1/9
         assert pytest.approx(abs(amp)**2, 1e-6) == 1/9
     
@@ -127,10 +127,10 @@ class TestTwoQubitGates:
         sim = Simulator(CNOT())
         results = sim.simulate(states, states)
         # Check that swap occurs when control qubit is 1 but not otherwise
-        amp = results[states[0]:states[0]]
-        assert pytest.approx(amp, 1e-6) == results[states[1]:states[1]]
-        assert pytest.approx(amp, 1e-6) == results[states[2]:states[3]]
-        assert pytest.approx(amp, 1e-6) == results[states[3]:states[2]]
+        amp = results[states[0], states[0]]
+        assert pytest.approx(amp, 1e-6) == results[states[1], states[1]]
+        assert pytest.approx(amp, 1e-6) == results[states[2], states[3]]
+        assert pytest.approx(amp, 1e-6) == results[states[3], states[2]]
         # Confirm success probability is 1/9
         assert pytest.approx(abs(amp)**2, 1e-6) == 1/9
     
@@ -147,10 +147,10 @@ class TestTwoQubitGates:
         sim = Simulator(CZ_Heralded())
         results = sim.simulate(states, states)
         # Check all results are identical except for |1,1> which has a -1
-        amp = results[states[0]:states[0]]
-        assert pytest.approx(amp, 1e-6) == results[states[1]:states[1]]
-        assert pytest.approx(amp, 1e-6) == results[states[2]:states[2]]
-        assert pytest.approx(amp, 1e-6) == -results[states[3]:states[3]]
+        amp = results[states[0], states[0]]
+        assert pytest.approx(amp, 1e-6) == results[states[1], states[1]]
+        assert pytest.approx(amp, 1e-6) == results[states[2], states[2]]
+        assert pytest.approx(amp, 1e-6) == -results[states[3], states[3]]
         # Confirm success probability is 1/16
         assert pytest.approx(abs(amp)**2, 1e-6) == 1/16
     
@@ -167,9 +167,9 @@ class TestTwoQubitGates:
         sim = Simulator(CNOT_Heralded())
         results = sim.simulate(states, states)
         # Check that swap occurs when control qubit is 1 but not otherwise
-        amp = results[states[0]:states[0]]
-        assert pytest.approx(amp, 1e-6) == results[states[1]:states[1]]
-        assert pytest.approx(amp, 1e-6) == results[states[2]:states[3]]
-        assert pytest.approx(amp, 1e-6) == results[states[3]:states[2]]
+        amp = results[states[0], states[0]]
+        assert pytest.approx(amp, 1e-6) == results[states[1], states[1]]
+        assert pytest.approx(amp, 1e-6) == results[states[2], states[3]]
+        assert pytest.approx(amp, 1e-6) == results[states[3], states[2]]
         # Confirm success probability is 1/16
         assert pytest.approx(abs(amp)**2, 1e-6) == 1/16


### PR DESCRIPTION
The indexing method for specifing an input & output in simulation result was changed to allow multiple values to be provided to [] instead of slicing.
While slicing worked well, this is more aligned with other Python modules so should hopefully feel more consistent.
The docs and tests were also updated to reflect this change.