### PR TITLE
Removed persistence of extra result attributes when threshold or parity mappings are applied.

### DIFF
--- a/lightworks/emulator/results/sampling_result.py
+++ b/lightworks/emulator/results/sampling_result.py
@@ -151,13 +151,7 @@ class SamplingResult:
         
     def _recombine_mapped_result(self, mapped_result: dict):
         """Creates a new Result object from mapped data."""
-        r = SamplingResult(mapped_result, self.input)
-        for k, v in self.__dict__.items():
-            if k not in ['input', 'outputs', 'dictionary', 
-                         '_SamplingResult__input', '_SamplingResult__outputs', 
-                         '_SamplingResult__dict']:
-                r.__dict__[k] = v
-        return r
+        return SamplingResult(mapped_result, self.input)
         
     def plot(self, show: bool = False, 
              state_labels: dict = {}) -> tuple | None:

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -241,9 +241,6 @@ class SimulationResult:
         r =  SimulationResult(array, result_type = self.result_type,
                               inputs = self.inputs, 
                               outputs = list(unique_outputs))
-        for k, v in self.__dict__.items():
-            if k not in ['result_type', 'array', 'inputs', 'outputs', 'r']:
-                r.__dict__[k] = v
         return r
     
     def plot(self, conv_to_probability: bool = False, show: bool = False,

--- a/tests/emulator/result_test.py
+++ b/tests/emulator/result_test.py
@@ -153,5 +153,5 @@ class TestSimulationResult:
         """
         r = SimulationResult(self.test_array, "probability_amplitude", 
                              inputs = self.test_inputs, 
-                             outputs = self.test_outputs, test_attr = 2.5)
-        assert r.test_attr == 2.5
+                             outputs = self.test_outputs, performance = 2.5)
+        assert r.performance == 2.5


### PR DESCRIPTION
Removed carry over of additional attributes which may be stored in a results object when a parity or threshold mapping is applied. 

This was creating a bug with the mappings in the simulation object, and given that the results are modified when these mappings are applied it doesn't make sense to preserve these attributes.