### PR TITLE
Fixed incorrect bs placement when the second mode is not specified in circuit add_bs method.

### DIFF
--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -278,10 +278,10 @@ class Circuit:
                 splitter, should be either "Rx" (the default value) or "H".
                 
         """
-        mode_1 = self._map_mode(mode_1)
-        self._mode_in_range(mode_1)
         if mode_2 is None: 
             mode_2 = mode_1 + 1
+        mode_1 = self._map_mode(mode_1)
+        self._mode_in_range(mode_1)
         mode_2 = self._map_mode(mode_2)
         if mode_1 == mode_2:
             raise ModeRangeError(

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -625,6 +625,23 @@ class TestCircuit:
         circuit.add(sub_circuit, 2)
         assert circuit.input_modes == n - 2
         
+    @pytest.mark.parametrize("initial_modes,final_modes",[[(0,),(0,2)], 
+                                                          [(2,),(5,6)],
+                                                          [(2,3),(5,6)],
+                                                          [(0,2),(0,5)]])
+    def test_bs_correct_modes(self, initial_modes, final_modes):
+        """
+        Checks that when a circuit has internal modes then the beam splitter is
+        applied correctly across the other modes. 
+        """
+        circuit = Circuit(7)
+        circuit._Circuit__internal_modes = [1, 3, 4]
+        # Add bs on modes
+        circuit.add_bs(*initial_modes)
+        # Then check modes are converted to correct values
+        assert circuit._Circuit__circuit_spec[0][1][0] == final_modes[0]
+        assert circuit._Circuit__circuit_spec[0][1][1] == final_modes[1]
+        
 class TestUnitary:
     """
     Unit tests to confirm correct functioning of the Unitary class when various 


### PR DESCRIPTION
In this case the second mode would often end up too large. This related to how circuit modes are remapped when heralds are used, and the point at which mode 2 was calculated when it wasn't specified.

A set of tests was added to check for this going forward.