### PR TITLE
Added compatiability for mpl display type with circuit heralds

### DIFF
--- a/lightworks/sdk/utils/circuit_utils.py
+++ b/lightworks/sdk/utils/circuit_utils.py
@@ -114,6 +114,9 @@ def add_empty_mode_to_circuit_spec(circuit_spec: list, mode: int) -> list:
             params[0] = swaps
         elif c == "group":
             params[0] = add_empty_mode_to_circuit_spec(params[0], mode)
+            # Shift unitary mode range
+            params[2] += 1 if params[2] >= mode else 0
+            params[3] += 1 if params[3] >= mode else 0
             # Update herald values
             in_heralds, out_heralds = params[4]["input"], params[4]["output"]
             new_in_heralds = {}
@@ -128,9 +131,6 @@ def add_empty_mode_to_circuit_spec(circuit_spec: list, mode: int) -> list:
                 new_out_heralds[m] = n
             params[4] = {"input" : new_in_heralds, 
                             "output" : new_out_heralds}
-            # Shift unitary mode range
-            params[2] += 1 if params[2] >= mode else 0
-            params[3] += 1 if params[3] >= mode else 0
         elif c == "unitary":
             params[0] += 1 if params[0] >= mode else 0
             # Expand unitary if required

--- a/lightworks/sdk/visualisation/display.py
+++ b/lightworks/sdk/visualisation/display.py
@@ -54,10 +54,6 @@ def Display(circuit: "Circuit", display_loss: bool = False,                    #
     """
     
     if display_type == "mpl":
-        if circuit.heralds["input"]:
-            raise NotImplementedError(
-                "MPL display method does not currently support inclusion of "
-                "heralds.")
         disp = DrawCircuitMPL(circuit, display_loss, mode_labels)
         fig, ax = disp.draw()
         return (fig, ax)

--- a/lightworks/sdk/visualisation/display_components_mpl.py
+++ b/lightworks/sdk/visualisation/display_components_mpl.py
@@ -34,9 +34,9 @@ class DisplayComponentsMPL:
         con_length = 0.5
         # Get x and y locs of target modes
         xloc = self.locations[mode]
-        yloc = mode
+        yloc = self.y_locations[mode]
         # Add input waveguides
-        self._add_wg(xloc, mode, con_length)
+        self._add_wg(xloc, yloc, con_length)
         xloc += con_length
         # Add phase shifter square
         rect = patches.Rectangle((xloc, yloc-size/2), size, size, 
@@ -74,7 +74,7 @@ class DisplayComponentsMPL:
                      verticalalignment = "center")
         xloc += size
         # Add output waveguides
-        self._add_wg(xloc, mode, con_length)
+        self._add_wg(xloc, yloc, con_length)
         # Update mode locations list
         self.locations[mode] = xloc + con_length
         
@@ -85,19 +85,20 @@ class DisplayComponentsMPL:
         size_x = 0.5 # x beam splitter size
         con_length = 0.5 # input/output waveguide length
         offset = 0.5 # Offset of beam splitter shape from mode centres
-        size_y = offset + abs(mode2 - mode1) # Find y size
+        size_y = offset + abs(self.y_locations[mode2] - 
+                              self.y_locations[mode1]) # Find y size
         # Get x and y locations
-        yloc = min(mode1, mode2)
+        yloc = self.y_locations[min(mode1, mode2)]
         xloc = max(self.locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.locations[mode1:mode2+1]):
             if loc < xloc and i+mode1 not in self.herald_modes:
-                self._add_wg(loc, yloc + i, xloc - loc)
+                self._add_wg(loc, self.y_locations[i+mode1], xloc - loc)
         # Add input waveguides for all included modes
         modes = range(min(mode1, mode2), max(mode1, mode2) + 1, 1)
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length)
+                self._add_wg(xloc, self.y_locations[i], con_length)
         xloc += con_length
         # Add beam splitter rectangle shape
         rect = patches.Rectangle((xloc, yloc-offset/2), size_x, size_y, 
@@ -118,12 +119,12 @@ class DisplayComponentsMPL:
         # across the beam splitter
         for i in range(mode1+1, mode2):
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, size_x)
+                self._add_wg(xloc, self.y_locations[i], size_x)
         xloc += size_x
         # Add output waveguides and update mode locations
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length)
+                self._add_wg(xloc, self.y_locations[i], con_length)
             self.locations[i] = xloc + con_length
             
         return
@@ -135,9 +136,9 @@ class DisplayComponentsMPL:
         con_length = 0.5
         # Get x and y locations
         xloc = self.locations[mode]
-        yloc = mode
+        yloc = self.y_locations[mode]
         # Add an input waveguide
-        self._add_wg(xloc, mode, con_length)
+        self._add_wg(xloc, yloc, con_length)
         xloc += con_length
         # Add loss elements
         rect = patches.Rectangle((xloc, yloc-size/2), size, size, 
@@ -156,7 +157,7 @@ class DisplayComponentsMPL:
                      verticalalignment = "center")
         xloc += size
         # Add output waveguide
-        self._add_wg(xloc, mode, con_length)
+        self._add_wg(xloc, yloc, con_length)
         # Update mode position
         self.locations[mode] = xloc + con_length
         
@@ -189,16 +190,16 @@ class DisplayComponentsMPL:
         ylocs = []
         for i, j in swaps.items():
             if i not in self.herald_modes:
-                ylocs.append((i, j))
+                ylocs.append((self.y_locations[i], self.y_locations[j]))
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.locations[min_mode:max_mode+1]):
             if loc < xloc and i + min_mode not in self.herald_modes:
-                self._add_wg(loc, min_mode + i, xloc - loc)
+                self._add_wg(loc, self.y_locations[min_mode + i], xloc - loc)
         # Add input waveguides for all included modes
         modes = range(min_mode, max_mode + 1, 1)
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length)
+                self._add_wg(xloc, self.y_locations[i], con_length)
         xloc += con_length
         for y0, y1 in ylocs:
             w = self.wg_width/2
@@ -218,7 +219,7 @@ class DisplayComponentsMPL:
         # Add output waveguides update mode locations
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length)
+                self._add_wg(xloc, self.y_locations[i], con_length)
             self.locations[i] = xloc + con_length
             
         return
@@ -228,19 +229,20 @@ class DisplayComponentsMPL:
         size_x = 1 # Unitary x size
         con_length = 0.5 # Input/output waveguide lengths
         offset = 0.5 # Offset of unitary square from modes
-        size_y = offset + abs(mode2 - mode1) # Find total unitary size
+        size_y = offset + abs(self.y_locations[mode2] - 
+                              self.y_locations[mode1]) # Find total unitary size
         # Get x and y positions
-        yloc = min(mode1, mode2)
+        yloc = self.y_locations[min(mode1, mode2)]
         xloc = max(self.locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.locations[mode1:mode2+1]):
             if loc < xloc and i + mode1 not in self.herald_modes:
-                self._add_wg(loc, yloc + i, xloc - loc)
+                self._add_wg(loc, self.y_locations[i+mode1], xloc - loc)
         # Add input waveguides
         modes = range(min(mode1, mode2), max(mode1, mode2)+1, 1)
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length)
+                self._add_wg(xloc, self.y_locations[i], con_length)
         xloc += con_length
         # Add unitary shape and label
         rect = patches.Rectangle((xloc, yloc-offset/2), size_x, size_y, 
@@ -249,7 +251,7 @@ class DisplayComponentsMPL:
         self.ax.add_patch(rect)
         s = 10 if len(label) == 1 else 8
         r = 90 if len(label) > 2 else 0
-        self.ax.text(xloc + size_x/2, yloc + abs(mode2 - mode1)/2, 
+        self.ax.text(xloc + size_x/2, yloc + (size_y-offset)/2, 
                      label, horizontalalignment = "center", size = s,
                      verticalalignment = "center", color = "white",
                      rotation = r)
@@ -257,7 +259,7 @@ class DisplayComponentsMPL:
         # Add output waveguides and update mode positions
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length)
+                self._add_wg(xloc, self.y_locations[i], con_length)
             self.locations[i] = xloc + con_length
             
         return
@@ -269,21 +271,24 @@ class DisplayComponentsMPL:
         con_length = 0.5 # Input/output waveguide lengths
         extra_length = 0.5 if heralds["input"] or heralds["output"] else 0
         offset = 0.5 # Offset of square from modes
-        size_y = offset + abs(mode2 - mode1) # Find total unitary size
+        size_y = offset + abs(self.y_locations[mode2] - 
+                              self.y_locations[mode1]) # Find total unitary size
         # Get x and y positions
-        yloc = min(mode1, mode2)
+        yloc = self.y_locations[min(mode1, mode2)]
         xloc = max(self.locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.locations[mode1:mode2+1]):
             if loc < xloc and i+mode1 not in self.herald_modes:
-                self._add_wg(loc, yloc + i, xloc - loc)
+                self._add_wg(loc, self.y_locations[i+mode1], xloc - loc)
         # Add input waveguides
         modes = range(min(mode1, mode2), max(mode1, mode2)+1, 1)
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length + extra_length)
+                self._add_wg(xloc, self.y_locations[i], 
+                             con_length + extra_length)
             elif i - mode1 in heralds["input"]:
-                self._add_wg(xloc + extra_length, i, con_length)
+                self._add_wg(xloc + extra_length, self.y_locations[i], 
+                             con_length)
         xloc += con_length + extra_length
         # Add circuit shape and label
         rect = patches.Rectangle((xloc, yloc-offset/2), size_x, size_y, 
@@ -292,7 +297,7 @@ class DisplayComponentsMPL:
         self.ax.add_patch(rect)
         s = 10 if len(name) == 1 else 8
         r = 90 if len(name) > 2 else 0
-        self.ax.text(xloc + size_x/2, yloc + abs(mode2 - mode1)/2, 
+        self.ax.text(xloc + size_x/2, yloc + (size_y-offset)/2, 
                      name, horizontalalignment = "center", size = s,
                      verticalalignment = "center", color = "white", 
                      rotation = r)
@@ -300,9 +305,10 @@ class DisplayComponentsMPL:
         # Add output waveguides and update mode positions
         for i in modes:
             if i not in self.herald_modes:
-                self._add_wg(xloc, i, con_length + extra_length)
+                self._add_wg(xloc, self.y_locations[i], 
+                             con_length + extra_length)
             elif i - mode1 in heralds["output"]:
-                self._add_wg(xloc, i, con_length)
+                self._add_wg(xloc, self.y_locations[i], con_length)
             self.locations[i] = xloc + con_length + extra_length
             
         # Modify provided heralds by mode offset and then add at locations
@@ -322,7 +328,7 @@ class DisplayComponentsMPL:
         # Input heralds
         for mode, num in heralds["input"].items():
             xloc = start_loc
-            yloc = mode
+            yloc = self.y_locations[mode]
             circle = patches.Circle((xloc, yloc), size, facecolor = "#3e368d", 
                                     edgecolor = "black")
             self.ax.add_patch(circle)
@@ -332,7 +338,7 @@ class DisplayComponentsMPL:
         # Output heralds
         for mode, num in heralds["output"].items():
             xloc = end_loc
-            yloc = mode
+            yloc = self.y_locations[mode]
             circle = patches.Circle((xloc, yloc), size, facecolor = "#3e368d", 
                                     edgecolor = "black")
             self.ax.add_patch(circle)

--- a/lightworks/sdk/visualisation/display_components_mpl.py
+++ b/lightworks/sdk/visualisation/display_components_mpl.py
@@ -299,3 +299,28 @@ class DisplayComponentsMPL:
             self.locations[i] = xloc + con_length
             
         return
+    
+    def _add_heralds(self, heralds: dict, start_loc: float, 
+                     end_loc: float) -> None:
+        """Adds display of all heralds to circuit."""
+        size = 0.25
+        # Input heralds
+        for mode, num in heralds["input"].items():
+            xloc = start_loc
+            yloc = mode
+            circle = patches.Circle((xloc, yloc), size, facecolor = "#3e368d", 
+                                    edgecolor = "black")
+            self.ax.add_patch(circle)
+            self.ax.text(xloc, yloc+0.01, str(num), color = "white", size = 8, 
+                         horizontalalignment = "center", 
+                         verticalalignment = "center")
+        # Output heralds
+        for mode, num in heralds["output"].items():
+            xloc = end_loc
+            yloc = mode
+            circle = patches.Circle((xloc, yloc), size, facecolor = "#3e368d", 
+                                    edgecolor = "black")
+            self.ax.add_patch(circle)
+            self.ax.text(xloc, yloc+0.01, str(num), color = "white", size = 8, 
+                         horizontalalignment = "center", 
+                         verticalalignment = "center")

--- a/lightworks/sdk/visualisation/display_components_svg.py
+++ b/lightworks/sdk/visualisation/display_components_svg.py
@@ -84,11 +84,11 @@ class SVGDrawSpec:
         xloc = max(self.x_locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.x_locations[mode1:mode2+1]):
-            if loc < xloc and i+mode1 not in self.circuit._internal_modes:
+            if loc < xloc and i+mode1 not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[mode1+i], xloc - loc)
         # Add input waveguides for all included modes
         for i in range(mode1, mode2 + 1):
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
         xloc += con_length
         # Add beam splitter section
@@ -96,7 +96,7 @@ class SVGDrawSpec:
         # TODO: Need to tweak how the beam splitter location is decided
         mode_between = 0
         for i in range(mode1 + 1, mode2 + 1, 1):
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 mode_between += 1
         dy = - 50 if mode_between%2 == 0 else 0
         self.draw_spec += [("text", ("BS", xloc+size_x/2, 
@@ -109,17 +109,14 @@ class SVGDrawSpec:
                                      "centred"))]
         # For any modes in between the beam splitter modes add a waveguide 
         # across the beam splitter
-        if mode2 - mode1 > 1:
-            for i in range(mode1+1, mode2):
-                if i not in self.circuit._internal_modes:
-                    self._add_wg(xloc, self.y_locations[i], size_x)
+        for i in range(mode1+1, mode2):
+            if i not in self.herald_modes:
+                self._add_wg(xloc, self.y_locations[i], size_x)
         xloc += size_x
-        # Add output waveguides
+        # Add output waveguides and update mode locations
         for i in range(mode1, mode2 + 1):
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
-        # Update mode locations
-        for i in range(mode1, mode2 + 1):
             self.x_locations[i] = xloc + con_length
         
         return
@@ -135,12 +132,12 @@ class SVGDrawSpec:
         xloc = max(self.x_locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.x_locations[mode1:mode2+1]):
-            if loc < xloc and i + mode1 not in self.circuit._internal_modes:
+            if loc < xloc and i + mode1 not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[mode1 + i], xloc - loc)
         # Add input waveguides
         modes = range(min(mode1, mode2), max(mode1, mode2)+1, 1)
         for i in modes:
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
         xloc += con_length
         # Add unitary shape and U label
@@ -154,7 +151,7 @@ class SVGDrawSpec:
         xloc += size_x
         # Add output waveguides and update mode positions
         for i in modes:
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
             self.x_locations[i] = xloc + con_length
             
@@ -215,26 +212,25 @@ class SVGDrawSpec:
         xloc = max(self.x_locations[min_mode:max_mode+1])
         ylocs = []
         for i, j in swaps.items():
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 ylocs.append((self.y_locations[i], self.y_locations[j]))
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.x_locations[min_mode:max_mode+1]):
-            if loc < xloc and i + min_mode not in self.circuit._internal_modes:
+            if loc < xloc and i + min_mode not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[min_mode+i], xloc - loc)
         # Add input waveguides for all included modes
         modes = range(min_mode, max_mode+1, 1)
         for i in modes:
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
         xloc += con_length
         # Add beam splitter section
         self.draw_spec += [("mode_swaps", (xloc, ylocs, size_x))]
         xloc += size_x
-        # Add output waveguides
+        # Add output waveguides update mode locations
         for i in modes:
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
-            # Update mode locations
             self.x_locations[i] = xloc + con_length
         
         return
@@ -252,12 +248,12 @@ class SVGDrawSpec:
         xloc = max(self.x_locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
         for i, loc in enumerate(self.x_locations[mode1:mode2+1]):
-            if loc < xloc and i+mode1 not in self.circuit._internal_modes:
+            if loc < xloc and i+mode1 not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[mode1 + i], xloc - loc)
         # Add input waveguides
         modes = range(min(mode1, mode2), max(mode1, mode2)+1, 1)
         for i in modes:
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length + extra_length)
             elif i - mode1 in heralds["input"]:
                 self._add_wg(xloc + extra_length, self.y_locations[i], con_length)
@@ -273,7 +269,7 @@ class SVGDrawSpec:
         xloc += size_x
         # Add output waveguides and update mode positions
         for i in modes:
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length + extra_length)
             elif i - mode1 in heralds["output"]:
                 self._add_wg(xloc, self.y_locations[i], con_length)
@@ -284,7 +280,8 @@ class SVGDrawSpec:
             "input" : {m+mode1:n for m, n in heralds["input"].items()},
             "output" : {m+mode1:n for m, n in heralds["output"].items()}
             }
-        self._add_heralds(shifted_heralds, xloc-size_x-50, xloc+50)
+        self._add_heralds(shifted_heralds, xloc-size_x-con_length, 
+                          xloc+con_length)
             
         return
     

--- a/lightworks/sdk/visualisation/draw_circuit_mpl.py
+++ b/lightworks/sdk/visualisation/draw_circuit_mpl.py
@@ -125,11 +125,25 @@ class DrawCircuitMPL(DisplayComponentsMPL):
         self.ax.set_xlim(0, max(self.locations) + 0.5)
         self.ax.set_yticks(range(0, N))
         if self.mode_labels is not None:
-            if len(self.mode_labels) != N:
+            exp_len = N - len(self.herald_modes)
+            if len(self.mode_labels) != exp_len:
                 raise DisplayError(
                     "Length of provided mode labels list should be equal to "
-                    "the number of modes.")
-            self.ax.set_yticklabels(self.mode_labels)
+                    f"the number of useable modes ({exp_len}).")
+            mode_labels = self.mode_labels
+        else:
+            mode_labels = range(N - len(self.herald_modes))
+        mode_labels = [str(m) for m in mode_labels]
+        # Include heralded modes in mode labels
+        full_mode_labels = []
+        count = 0
+        for i in range(N):
+            if i not in self.herald_modes:
+                full_mode_labels.append(mode_labels[count])
+                count += 1
+            else:
+                full_mode_labels.append("-")
+        self.ax.set_yticklabels(full_mode_labels)
         self.ax.set_xticks([])
 
         return self.fig, self.ax

--- a/lightworks/sdk/visualisation/draw_circuit_mpl.py
+++ b/lightworks/sdk/visualisation/draw_circuit_mpl.py
@@ -46,6 +46,7 @@ class DrawCircuitMPL(DisplayComponentsMPL):
         self.display_loss = display_loss
         self.mode_labels = mode_labels
         self.N = self.circuit.n_modes
+        self.herald_modes = self.circuit._internal_modes
         
     def draw(self) -> tuple[plt.figure, plt.axes]:
         
@@ -71,7 +72,7 @@ class DrawCircuitMPL(DisplayComponentsMPL):
         # Add extra waveguides when using heralds
         if self.circuit._external_heralds["input"]:
             for i in range(self.N):
-                if i not in self.circuit._internal_modes:
+                if i not in self.herald_modes:
                     self._add_wg(self.locations[i], i, 0.5)
                     self.locations[i] += 0.5
         # Loop over build spec and add each component
@@ -103,14 +104,15 @@ class DrawCircuitMPL(DisplayComponentsMPL):
                 m1, m2 = modes
                 if m1 > m2:
                     m1, m2 = m2, m1
-                self._add_grouped_circuit(m1, m2, params)
+                name, heralds = params
+                self._add_grouped_circuit(m1, m2, name, heralds)
         # Add any final lengths as required
         final_loc = max(self.locations)
         # Extend final waveguide if herald included
         if (self.circuit._external_heralds["output"]):
             final_loc += 0.5
         for i, loc in enumerate(self.locations):    
-            if loc < final_loc:
+            if loc < final_loc and i not in self.herald_modes:
                 length = final_loc - loc
                 self._add_wg(loc, i, length)
                 self.locations[i] += length

--- a/lightworks/sdk/visualisation/draw_circuit_mpl.py
+++ b/lightworks/sdk/visualisation/draw_circuit_mpl.py
@@ -62,7 +62,19 @@ class DrawCircuitMPL(DisplayComponentsMPL):
         # Manually adjust figure height
         h = max(N, 4)
         self.fig.set_figheight(h)
-        self.ax.set_ylim(N, -1)
+        dy = 1
+        dy_smaller = 0.6
+        self.y_locations = []
+        # Set mode y locations
+        yloc = 0
+        for i in range(self.N):
+            self.y_locations.append(yloc)
+            if i+1 in self.herald_modes:
+                yloc += dy_smaller
+            elif i in self.herald_modes:
+                yloc += dy_smaller
+            else:
+                yloc += dy
         # Set a starting length and add a waveguide for each mode
         init_length = 0.5
         if False:
@@ -73,7 +85,7 @@ class DrawCircuitMPL(DisplayComponentsMPL):
         if self.circuit._external_heralds["input"]:
             for i in range(self.N):
                 if i not in self.herald_modes:
-                    self._add_wg(self.locations[i], i, 0.5)
+                    self._add_wg(self.locations[i], self.y_locations[i], 0.5)
                     self.locations[i] += 0.5
         # Loop over build spec and add each component
         for spec in self.circuit._display_spec:
@@ -114,7 +126,7 @@ class DrawCircuitMPL(DisplayComponentsMPL):
         for i, loc in enumerate(self.locations):    
             if loc < final_loc and i not in self.herald_modes:
                 length = final_loc - loc
-                self._add_wg(loc, i, length)
+                self._add_wg(loc, self.y_locations[i], length)
                 self.locations[i] += length
                 
         # Add heralding display
@@ -123,7 +135,8 @@ class DrawCircuitMPL(DisplayComponentsMPL):
                 
         # Set axes limits using locations and mode numbers
         self.ax.set_xlim(0, max(self.locations) + 0.5)
-        self.ax.set_yticks(range(0, N))
+        self.ax.set_ylim(max(self.y_locations) + 1, -1)
+        self.ax.set_yticks(self.y_locations)
         if self.mode_labels is not None:
             exp_len = N - len(self.herald_modes)
             if len(self.mode_labels) != exp_len:

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -42,7 +42,7 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
         
         self.circuit = circuit
         self.display_loss = display_loss
-        self.mode_labels = mode_labels
+        self.herald_modes = self.circuit._internal_modes
         # Set a waveguide width and get mode number
         self.wg_width = 8
         self.N = self.circuit.n_modes
@@ -54,22 +54,22 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
         yloc = self.dy
         for i in range(self.N):
             self.y_locations.append(yloc)
-            if i+1 in self.circuit._internal_modes:
+            if i+1 in self.herald_modes:
                 yloc += self.dy_smaller
-            elif i in self.circuit._internal_modes:
+            elif i in self.herald_modes:
                 yloc += self.dy_smaller
             else:
                 yloc += self.dy
         init_length = 100
         # Add the mode labels
         if mode_labels is None:
-            mode_labels = range(self.N - len(self.circuit._internal_modes))
+            mode_labels = range(self.N - len(self.herald_modes))
         # Convert all labels to strings
         mode_labels = [str(m) for m in mode_labels]
         full_mode_labels = []
         count = 0
         for i in range(self.circuit.n_modes):
-            if i not in self.circuit._internal_modes:
+            if i not in self.herald_modes:
                 full_mode_labels.append(mode_labels[count])
                 count += 1
             else:
@@ -90,7 +90,7 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
         # Add extra waveguides when using heralds
         if self.circuit._external_heralds["input"]:
             for m in range(self.N):
-                if m not in self.circuit._internal_modes:
+                if m not in self.herald_modes:
                     self._add_wg(self.x_locations[m], self.y_locations[m], 50)
                     self.x_locations[m] += 50
         # Loop over each element in the build spec and add
@@ -130,7 +130,7 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
         if self.circuit._external_heralds["output"]:
             maxloc += 50
         for i, loc in enumerate(self.x_locations):
-            if loc < maxloc and i not in self.circuit._internal_modes:
+            if loc < maxloc and i not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[i], maxloc-loc)
                 self.x_locations[i] = maxloc
         
@@ -194,7 +194,7 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
                 raise DisplayError("Element in draw spec not recognised.")
                 
         # Adjust size of figure to meet target scale
-        target_scale = min(50+(self.N-len(self.circuit._internal_modes))*65, 900)
+        target_scale = min(50+(self.N-len(self.herald_modes))*65, 900)
         #target_scale = max(target_scale, 200)
         self.d.set_pixel_scale(1)
         w,h = self.d.calc_render_size()

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -62,13 +62,19 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
                 yloc += self.dy
         init_length = 100
         # Add the mode labels
-        if mode_labels is None:
+        if mode_labels is not None:
+            exp_len = self.N - len(self.herald_modes)
+            if len(mode_labels) != exp_len:
+                raise DisplayError(
+                    "Length of provided mode labels list should be equal to "
+                    f"the number of useable modes ({exp_len}).")
+        else:
             mode_labels = range(self.N - len(self.herald_modes))
         # Convert all labels to strings
         mode_labels = [str(m) for m in mode_labels]
         full_mode_labels = []
         count = 0
-        for i in range(self.circuit.n_modes):
+        for i in range(self.N):
             if i not in self.herald_modes:
                 full_mode_labels.append(mode_labels[count])
                 count += 1

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -88,8 +88,7 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
         # Create list of locations for each mode
         self.x_locations = [init_length+50]*self.N
         # Add extra waveguides when using heralds
-        if (self.circuit._external_heralds["input"] or 
-            self.circuit._external_heralds["output"]):
+        if self.circuit._external_heralds["input"]:
             for m in range(self.N):
                 if m not in self.circuit._internal_modes:
                     self._add_wg(self.x_locations[m], self.y_locations[m], 50)
@@ -127,8 +126,8 @@ class DrawCircuitSVG(SVGDrawSpec, DisplayComponentsSVG):
                 self._add_grouped_circuit(m1, m2, name, heralds)
         
         maxloc = max(self.x_locations)
-        if (self.circuit._external_heralds["input"] or 
-            self.circuit._external_heralds["output"]):
+        # Extend final waveguide if herald included
+        if self.circuit._external_heralds["output"]:
             maxloc += 50
         for i, loc in enumerate(self.x_locations):
             if loc < maxloc and i not in self.circuit._internal_modes:

--- a/tests/sdk/display_test.py
+++ b/tests/sdk/display_test.py
@@ -85,7 +85,6 @@ class TestDisplay:
         except:
             pytest.fail("Exception occurred during display operation.")
     
-    @pytest.mark.skip()
     def test_circuit_display_function_mpl(self):
         """
         Checks that a circuit passed to the display function is able to be


### PR DESCRIPTION
Implemented the required updates to the mpl display method so that heralds assocaited with a circuit can be displayed.

In this PR a bug with the location of heralds in grouped components was also fixed. This occured when heralds were shifted as new heralds are added to a circuit. It only affected the display method and not simulation functionality.