### PR TITLE
Barrier waveguide placement fix

### DIFF
--- a/lightworks/sdk/visualisation/display_components_mpl.py
+++ b/lightworks/sdk/visualisation/display_components_mpl.py
@@ -33,7 +33,7 @@ class DisplayComponentsMPL:
         size = 0.5
         con_length = 0.5
         # Get x and y locs of target modes
-        xloc = self.locations[mode]
+        xloc = self.x_locations[mode]
         yloc = self.y_locations[mode]
         # Add input waveguides
         self._add_wg(xloc, yloc, con_length)
@@ -76,7 +76,7 @@ class DisplayComponentsMPL:
         # Add output waveguides
         self._add_wg(xloc, yloc, con_length)
         # Update mode locations list
-        self.locations[mode] = xloc + con_length
+        self.x_locations[mode] = xloc + con_length
         
         return
     
@@ -89,9 +89,9 @@ class DisplayComponentsMPL:
                               self.y_locations[mode1]) # Find y size
         # Get x and y locations
         yloc = self.y_locations[min(mode1, mode2)]
-        xloc = max(self.locations[mode1:mode2+1])
+        xloc = max(self.x_locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
-        for i, loc in enumerate(self.locations[mode1:mode2+1]):
+        for i, loc in enumerate(self.x_locations[mode1:mode2+1]):
             if loc < xloc and i+mode1 not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[i+mode1], xloc - loc)
         # Add input waveguides for all included modes
@@ -125,7 +125,7 @@ class DisplayComponentsMPL:
         for i in modes:
             if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
-            self.locations[i] = xloc + con_length
+            self.x_locations[i] = xloc + con_length
             
         return
     
@@ -135,7 +135,7 @@ class DisplayComponentsMPL:
         size = 0.5
         con_length = 0.5
         # Get x and y locations
-        xloc = self.locations[mode]
+        xloc = self.x_locations[mode]
         yloc = self.y_locations[mode]
         # Add an input waveguide
         self._add_wg(xloc, yloc, con_length)
@@ -159,7 +159,7 @@ class DisplayComponentsMPL:
         # Add output waveguide
         self._add_wg(xloc, yloc, con_length)
         # Update mode position
-        self.locations[mode] = xloc + con_length
+        self.x_locations[mode] = xloc + con_length
         
         return
     
@@ -170,12 +170,12 @@ class DisplayComponentsMPL:
         """
         max_loc = 0
         for m in modes:
-            max_loc = max(max_loc, self.locations[m])
+            max_loc = max(max_loc, self.x_locations[m])
         for m in modes:
-            loc = self.locations[m]
+            loc = self.x_locations[m]
             if loc < max_loc:
                 self._add_wg(loc, self.y_locations[m], max_loc - loc)
-            self.locations[m] = max_loc
+            self.x_locations[m] = max_loc
         
         return
     
@@ -186,13 +186,13 @@ class DisplayComponentsMPL:
         min_mode = min(swaps)
         max_mode = max(swaps)
         # Get x and y locations
-        xloc = max(self.locations[min_mode:max_mode+1])
+        xloc = max(self.x_locations[min_mode:max_mode+1])
         ylocs = []
         for i, j in swaps.items():
             if i not in self.herald_modes:
                 ylocs.append((self.y_locations[i], self.y_locations[j]))
         # Add initial connectors for any modes which haven't reach xloc yet:
-        for i, loc in enumerate(self.locations[min_mode:max_mode+1]):
+        for i, loc in enumerate(self.x_locations[min_mode:max_mode+1]):
             if loc < xloc and i + min_mode not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[min_mode + i], xloc - loc)
         # Add input waveguides for all included modes
@@ -220,7 +220,7 @@ class DisplayComponentsMPL:
         for i in modes:
             if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
-            self.locations[i] = xloc + con_length
+            self.x_locations[i] = xloc + con_length
             
         return
     
@@ -233,9 +233,9 @@ class DisplayComponentsMPL:
                               self.y_locations[mode1]) # Find total unitary size
         # Get x and y positions
         yloc = self.y_locations[min(mode1, mode2)]
-        xloc = max(self.locations[mode1:mode2+1])
+        xloc = max(self.x_locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
-        for i, loc in enumerate(self.locations[mode1:mode2+1]):
+        for i, loc in enumerate(self.x_locations[mode1:mode2+1]):
             if loc < xloc and i + mode1 not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[i+mode1], xloc - loc)
         # Add input waveguides
@@ -260,7 +260,7 @@ class DisplayComponentsMPL:
         for i in modes:
             if i not in self.herald_modes:
                 self._add_wg(xloc, self.y_locations[i], con_length)
-            self.locations[i] = xloc + con_length
+            self.x_locations[i] = xloc + con_length
             
         return
     
@@ -275,9 +275,9 @@ class DisplayComponentsMPL:
                               self.y_locations[mode1]) # Find total unitary size
         # Get x and y positions
         yloc = self.y_locations[min(mode1, mode2)]
-        xloc = max(self.locations[mode1:mode2+1])
+        xloc = max(self.x_locations[mode1:mode2+1])
         # Add initial connectors for any modes which haven't reach xloc yet:
-        for i, loc in enumerate(self.locations[mode1:mode2+1]):
+        for i, loc in enumerate(self.x_locations[mode1:mode2+1]):
             if loc < xloc and i+mode1 not in self.herald_modes:
                 self._add_wg(loc, self.y_locations[i+mode1], xloc - loc)
         # Add input waveguides
@@ -309,7 +309,7 @@ class DisplayComponentsMPL:
                              con_length + extra_length)
             elif i - mode1 in heralds["output"]:
                 self._add_wg(xloc, self.y_locations[i], con_length)
-            self.locations[i] = xloc + con_length + extra_length
+            self.x_locations[i] = xloc + con_length + extra_length
             
         # Modify provided heralds by mode offset and then add at locations
         shifted_heralds = {

--- a/lightworks/sdk/visualisation/display_components_mpl.py
+++ b/lightworks/sdk/visualisation/display_components_mpl.py
@@ -174,7 +174,7 @@ class DisplayComponentsMPL:
         for m in modes:
             loc = self.locations[m]
             if loc < max_loc:
-                self._add_wg(loc, m, max_loc - loc)
+                self._add_wg(loc, self.y_locations[m], max_loc - loc)
             self.locations[m] = max_loc
         
         return

--- a/lightworks/sdk/visualisation/display_components_svg.py
+++ b/lightworks/sdk/visualisation/display_components_svg.py
@@ -193,7 +193,7 @@ class SVGDrawSpec:
         for m in modes:
             loc = self.x_locations[m]
             if loc < max_loc:
-                self._add_wg(loc, (m+1)*self.dy, max_loc - loc)
+                self._add_wg(loc, self.y_locations[m], max_loc - loc)
             self.x_locations[m] = max_loc
         
         return

--- a/lightworks/sdk/visualisation/draw_circuit_mpl.py
+++ b/lightworks/sdk/visualisation/draw_circuit_mpl.py
@@ -80,13 +80,13 @@ class DrawCircuitMPL(DisplayComponentsMPL):
         if False:
             self._add_wg(0, i-self.wg_width/2, init_length)
         # Create a list to store the positions of each mode
-        self.locations = [init_length]*N
+        self.x_locations = [init_length]*N
         # Add extra waveguides when using heralds
         if self.circuit._external_heralds["input"]:
             for i in range(self.N):
                 if i not in self.herald_modes:
-                    self._add_wg(self.locations[i], self.y_locations[i], 0.5)
-                    self.locations[i] += 0.5
+                    self._add_wg(self.x_locations[i], self.y_locations[i], 0.5)
+                    self.x_locations[i] += 0.5
         # Loop over build spec and add each component
         for spec in self.circuit._display_spec:
             c, modes = spec[0:2]
@@ -119,22 +119,22 @@ class DrawCircuitMPL(DisplayComponentsMPL):
                 name, heralds = params
                 self._add_grouped_circuit(m1, m2, name, heralds)
         # Add any final lengths as required
-        final_loc = max(self.locations)
+        final_loc = max(self.x_locations)
         # Extend final waveguide if herald included
         if (self.circuit._external_heralds["output"]):
             final_loc += 0.5
-        for i, loc in enumerate(self.locations):    
+        for i, loc in enumerate(self.x_locations):    
             if loc < final_loc and i not in self.herald_modes:
                 length = final_loc - loc
                 self._add_wg(loc, self.y_locations[i], length)
-                self.locations[i] += length
+                self.x_locations[i] += length
                 
         # Add heralding display
         self._add_heralds(self.circuit._external_heralds, init_length,
                           final_loc)
                 
         # Set axes limits using locations and mode numbers
-        self.ax.set_xlim(0, max(self.locations) + 0.5)
+        self.ax.set_xlim(0, max(self.x_locations) + 0.5)
         self.ax.set_ylim(max(self.y_locations) + 1, -1)
         self.ax.set_yticks(self.y_locations)
         if self.mode_labels is not None:


### PR DESCRIPTION
Fixed an issue that occurred when barriers were used in a circuit, in which added waveguides were in the wrong y location.

Also converted locations attribute in mpl display to x_locations so this is more consistent.