### PR TITLE
Improve unit test coverage across package

### DIFF
--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -144,9 +144,6 @@ class SimulationResult:
                 return sub_r[ostate]
             else:
                 raise KeyError("Requested output state not in data.")
-        elif isinstance(item, slice):
-            raise DeprecationWarning(
-                "Retrieval of data through slicing is no longer supported.")
         else:
             raise ValueError(
                 "Get item value must be either one or two States.")
@@ -227,7 +224,8 @@ class SimulationResult:
                     mapped_result[in_state][new_s] = val
         return self._recombine_mapped_result(mapped_result)
     
-    def _recombine_mapped_result(self, mapped_result: dict):
+    def _recombine_mapped_result(self, mapped_result: dict
+                                 ) -> "SimulationResult":
         """Creates a new Result object from mapped data."""
         unique_outputs = set()
         for in_state, pdist in mapped_result.items():

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -422,8 +422,6 @@ class SimulationResult:
         if conv_to_probability:
             if self.result_type == "probability_amplitude":
                 data = abs(data)**2
-            elif self.result_type == "counts":
-                data = data/np.sum(data)
         # Apply thresholding to values
         for i in range(data.shape[0]):
             for j in range(data.shape[1]):

--- a/lightworks/qubit/gates/single_qubit_gates.py
+++ b/lightworks/qubit/gates/single_qubit_gates.py
@@ -30,19 +30,8 @@ class H(Unitary):
         
         unitary = np.array([[1,1],[1,-1]])/2**0.5
         super().__init__(unitary, "H")
-    
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate.
-        """
-        rep = """
-              _____
-        q0 --|     |-- q0
-             |  H  |
-        q1 --|_____|-- q1 
-        """
-        print(rep)
-        
+
+
 class X(Unitary):
     """
     Implements an X gate across a pair of modes corresponding to a dual-rail 
@@ -52,19 +41,8 @@ class X(Unitary):
         
         unitary = np.array([[0,1],[1,0]])
         super().__init__(unitary, "X")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate.
-        """
-        rep = """
-              _____
-        q0 --|     |-- q0
-             |  X  |
-        q1 --|_____|-- q1 
-        """
-        print(rep)
-        
+
+
 class Y(Unitary):
     """
     Implements a Y gate across a pair of modes corresponding to a dual-rail 
@@ -74,19 +52,8 @@ class Y(Unitary):
         
         unitary = np.array([[0,-1j],[1j,0]])
         super().__init__(unitary, "Y")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate.
-        """
-        rep = """
-              _____
-        q0 --|     |-- q0
-             |  Y  |
-        q1 --|_____|-- q1 
-        """
-        print(rep)
-        
+
+
 class Z(Unitary):
     """
     Implements a Z gate across a pair of modes corresponding to a dual-rail 
@@ -96,19 +63,8 @@ class Z(Unitary):
         
         unitary = np.array([[1,0],[0,-1]])
         super().__init__(unitary, "Z")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate.
-        """
-        rep = """
-              _____
-        q0 --|     |-- q0
-             |  Z  |
-        q1 --|_____|-- q1 
-        """
-        print(rep)
-        
+
+
 class S(Unitary):
     """
     Implements an S gate across a pair of modes corresponding to a dual-rail 
@@ -118,19 +74,8 @@ class S(Unitary):
         
         unitary = np.array([[1,0],[0,1j]])
         super().__init__(unitary, "S")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate.
-        """
-        rep = """
-              _____
-        q0 --|     |-- q0
-             |  S  |
-        q1 --|_____|-- q1 
-        """
-        print(rep)
-        
+
+
 class T(Unitary):
     """
     Implements a T gate across a pair of modes corresponding to a dual-rail 
@@ -140,15 +85,3 @@ class T(Unitary):
         
         unitary = np.array([[1,0],[0,np.exp(1j*np.pi/4)]])
         super().__init__(unitary, "T")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate.
-        """
-        rep = """
-              _____
-        q0 --|     |-- q0
-             |  T  |
-        q1 --|_____|-- q1 
-        """
-        print(rep)

--- a/lightworks/qubit/gates/two_qubit_gates.py
+++ b/lightworks/qubit/gates/two_qubit_gates.py
@@ -45,24 +45,8 @@ class CZ(Circuit):
         
         super().__init__(4)
         self.add(unitary, 0, group = True, name = "CZ")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate, detailing the location of
-        the qubits and modes used for post-selection/heralding as well as 
-        photon numbers on these modes.
-        """
-        rep = """
-              ______
-         0 --|      |-- 0 _
-        c0 --|      |--    | 1 photon
-        c1 --|  CZ  |--   _|
-        t0 --|      |--    | 1 photon
-        t1 --|      |--   _|
-         0 --|______|-- 0 
-        """
-        print(rep)
-        
+
+
 class CNOT(Circuit):
     """
     Post-selected CNOT gate that acts across two dual-rail encoded qubits. This 
@@ -83,24 +67,8 @@ class CNOT(Circuit):
         circ.add(H(), 2)
         
         self.add(circ, 0, group = True, name = "CNOT")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate, detailing the location of
-        the qubits and modes used for post-selection/heralding as well as 
-        photon numbers on these modes.
-        """
-        rep = """
-              ________
-         0 --|        |-- 0 _
-        c0 --|        |--    | 1 photon
-        c1 --|  CNOT  |--   _|
-        t0 --|        |--    | 1 photon
-        t1 --|        |--   _|
-         0 --|________|-- 0 
-        """
-        print(rep)
-        
+
+  
 class CZ_Heralded(Circuit):
     """
     Heralded version of the CZ gate which acts across two dual-rail encoded 
@@ -147,26 +115,8 @@ class CZ_Heralded(Circuit):
         
         super().__init__(4)
         self.add(unitary, 0, group = True, name = "CZ")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate, detailing the location of
-        the qubits and modes used for post-selection/heralding as well as 
-        photon numbers on these modes.
-        """
-        rep = """
-              ______
-         0 --|      |-- 0
-         1 --|      |-- 1 
-        c0 --|      |-- c0
-        c1 --|  CZ  |-- c1
-        t0 --|      |-- t0
-        t1 --|      |-- t1
-         1 --|      |-- 1
-         0 --|______|-- 0      
-        """
-        print(rep)
-        
+
+
 class CNOT_Heralded(Circuit):
     """
     Heralded version of the CNOT gate which acts across two dual-rail encoded 
@@ -190,22 +140,3 @@ class CNOT_Heralded(Circuit):
         circ.add(H(), 2)
         
         self.add(circ, 0, group = True, name = "CNOT (Heralded)")
-        
-    def show_layout(self):
-        """
-        Shows the mode layout of the selected gate, detailing the location of
-        the qubits and modes used for post-selection/heralding as well as 
-        photon numbers on these modes.
-        """
-        rep = """
-              ________
-         0 --|        |-- 0
-         1 --|        |-- 1 
-        c0 --|        |-- c0
-        c1 --|  CNOT  |-- c1
-        t0 --|        |-- t0
-        t1 --|        |-- t1
-         1 --|        |-- 1
-         0 --|________|-- 0    
-        """
-        print(rep)

--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -469,7 +469,7 @@ class Circuit:
         Returns all the Parameter objects used as part of creating the circuit.
         """
         all_params = []
-        for _, params in unpack_circuit_spec(deepcopy(self.__circuit_spec)):
+        for _, params in unpack_circuit_spec(self.__circuit_spec):
             for p in params:
                 if isinstance(p, Parameter) and p not in all_params:
                     all_params.append(p)

--- a/lightworks/sdk/utils/__init__.py
+++ b/lightworks/sdk/utils/__init__.py
@@ -14,7 +14,7 @@
 
 from .matrix_utils import (check_unitary, random_unitary, random_permutation,
                            add_mode_to_unitary)
-from .state_utils import fock_basis, state_to_string
+from .state_utils import state_to_string
 from .exceptions import *
 from .conversion import db_loss_to_transmission, transmission_to_db_loss
 from .permutation_conversion import permutation_mat_from_swaps_dict

--- a/lightworks/sdk/utils/state_utils.py
+++ b/lightworks/sdk/utils/state_utils.py
@@ -15,36 +15,6 @@
 """
 Script to store various useful functions for the simulation aspect of the code.
 """
-
-def fock_basis(N: int, n: int, statistic_type: str) -> list:
-    """
-    Returns the Fock basis for n photons in N modes for either bosonic of
-    fermionic statistics.
-    """
-    if statistic_type == "bosonic":
-        return list(_sums(N,n))
-    elif statistic_type == "fermionic":
-        return _fermionic_basis(N, n)
-    else:
-        raise ValueError("statistic_type should be 'bosonic' or 'fermionic'.")
-    
-def _fermionic_basis(N: int, n: int) -> list:
-    """This returns the possible states of n fermions in N modes as vectors."""
-    if n == 0:
-        return [[0]*N]
-    if N == n:
-        return [[1]*N]
-    arrays_with_zero = [[0]+arr for arr in _fermionic_basis(N - 1, n)]
-    arrays_with_one = [[1]+arr for arr in _fermionic_basis(N - 1, n - 1)]
-    return arrays_with_zero + arrays_with_one
-
-def _sums(length: int, total_sum: int):
-    if length == 1:
-        yield [total_sum,]
-    else:
-        for value in range(total_sum + 1):
-            for permutation in _sums(length-1, total_sum-value):
-                yield permutation + [value,]
                 
 def state_to_string(state: list) -> str:
     """Converts the provided state to a string with ket notation."""

--- a/tests/emulator/annotatedstate_test.py
+++ b/tests/emulator/annotatedstate_test.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from lightworks.emulator.annotated_state import AnnotatedState
+from lightworks.emulator.utils import annotated_state_to_string
 from lightworks.emulator import AnnotatedStateError
+from lightworks import State
 
 import pytest
 
@@ -31,6 +33,14 @@ class TestAnnotatedState:
                         AnnotatedState([[],[0],[1],[]])
         assert not AnnotatedState([[],[0],[1],[]]) ==  \
                          AnnotatedState([[],[1],[0],[]])
+                         
+    def test_state_equality_diff_types(self):
+        """
+        Checks that state equality returns False when compared with a 
+        non-AnnotatedState object.
+        """
+        s = AnnotatedState([[0],[1],[2]])
+        assert not s == [[0],[1],[2]]
     
     def test_state_equality_shuffled(self):
         """
@@ -74,3 +84,83 @@ class TestAnnotatedState:
         assert AnnotatedState([[],[0],[1,2],[],[0]]).n_photons == 4
         assert AnnotatedState([[],[],[],[]]).n_photons == 0
         assert AnnotatedState([]).n_photons == 0
+
+    @pytest.mark.parametrize("value", [[0,1,2], ["0", "1", "2"], [[0], 1], 
+                                       [0], [None]])
+    def test_req_list_of_lists(self, value):
+        """
+        Checks that a exception is raised in Annotated state isn't provided a 
+        list of lists as the input.
+        """
+        with pytest.raises(TypeError):
+            AnnotatedState(value)
+            
+    def test_n_modes_modification(self):
+        """
+        Tests that an exception is raised when a user attempts to modify an
+        AnnotatedState.
+        """
+        s = AnnotatedState([[0],[1],[2]])
+        with pytest.raises(AnnotatedStateError):
+            s.n_modes = 2
+        
+    def test_merge_not_same_length(self):
+        """
+        Confirms that merge method raises an exception when AnnotatedStates are
+        not of the same length.
+        """
+        s = AnnotatedState([[0],[1],[2]])
+        s2 = AnnotatedState([[0],[1],[2],[3]])
+        with pytest.raises(ValueError):
+            s.merge(s2)
+        with pytest.raises(ValueError):
+            s2.merge(s)
+    
+    @pytest.mark.parametrize("value", [(0,1,2),[0,1,2],State([0,1,2])])
+    def test_add_not_same_type(self, value):
+        """
+        Checks that an exception is raised when a non-AnnotatedState is 
+        attempted to be added to an AnnotatedState 
+        """
+        s = AnnotatedState([[0],[1],[2]])
+        with pytest.raises(TypeError):
+            s + value
+            
+    def test_str_returns_correct_value(self):
+        """
+        Checks that string function returns correct value for AnnotatedState.
+        """
+        s = [[0],[1],[2]]
+        assert str(AnnotatedState(s)) == annotated_state_to_string(s)
+        
+    def test_repr_returns_correct_value(self):
+        """
+        Checks that repr function contains correct value for AnnotatedState.
+        """
+        s = [[0],[1],[2]]
+        assert annotated_state_to_string(s) in str(AnnotatedState(s)) 
+        
+    def test_set_item_blocked(self):
+        """
+        Confirms that set item functionality is blocked for the AnnotatedState.
+        """
+        s = AnnotatedState([[0],[1],[2]])
+        with pytest.raises(AnnotatedStateError):
+            s[0] = [1]
+            
+    def test_get_item_slicing(self):
+        """
+        Checks that slicing can be used to get a part of an AnnotatedState.
+        """
+        s = AnnotatedState([[0],[1],[2],[3]])
+        assert s[0:2] == AnnotatedState([[0],[1]])
+        
+    @pytest.mark.parametrize("value", [[0,1], None, "1"])
+    def test_get_item_invalid_value(self, value):
+        """
+        Confirms error raised when an invalid value is provided to get item.
+        """
+        s = AnnotatedState([[0],[1],[2],[3]])
+        with pytest.raises(TypeError):
+            s[[0,1]]
+        

--- a/tests/emulator/backend_test.py
+++ b/tests/emulator/backend_test.py
@@ -130,6 +130,30 @@ class TestBackend:
             if round(p1[s], 8) != round(p2[s], 8):
                 pytest.fail("Methods do not produce equivalent distributions.")
                 
+    def test_clifford_not_implemented(self):
+        """
+        Confirms that clifford backend produces not-implemented error when 
+        trying to use it.
+        """
+        with pytest.raises(NotImplementedError):
+            Backend("clifford")
+            
+    def test_backend_str_return(self):
+        """
+        Check that backend value is stored and returned correctly when using
+        the str operator.
+        """
+        backend = Backend("permanent")
+        assert str(backend) == "permanent"
+        
+    def test_backend_repr_return(self):
+        """
+        Checks that backend value is correctly included in __repr__ for 
+        backend.
+        """
+        backend = Backend("permanent")
+        assert "permanent" in repr(backend)  
+                
 class TestPermanent:
     """
     Specific functions for testing Permanent calculation remains functional

--- a/tests/emulator/result_test.py
+++ b/tests/emulator/result_test.py
@@ -164,26 +164,51 @@ class TestSimulationResult:
     @pytest.fixture(autouse=True)
     def setup_data(self) -> None:
         """Create a variety of useful pieces of data for testing."""
-        self.test_inputs = [State([1,1,0,0]), State([0,0,1,1])]
-        self.test_outputs = [State([1,0,1,0]), State([0,1,0,1]), 
+        # Single input
+        self.test_single_inputs = [State([1,1,0,0])]
+        self.test_single_outputs = [State([1,0,1,0]), State([0,1,0,1]), 
                              State([0,0,2,0])]
-        self.test_array = array([[0.3, 0.2, 0.1], [0.2, 0.4, 0.5]])
+        self.test_single_array = array([[0.3, 0.2, 0.1]])
+        # Multiple inputs
+        self.test_multi_inputs = [State([1,1,0,0]), State([0,0,1,1])]
+        self.test_multi_outputs = [State([1,0,1,0]), State([0,1,0,1]), 
+                             State([0,0,2,0])]
+        self.test_multi_array = array([[0.3, 0.2, 0.1], [0.2, 0.4, 0.5]])
     
-    def test_array_result_creation(self):
+    def test_single_array_result_creation(self):
         """
-        Checks that a result object can be created with an array successfully.
+        Checks that a result object can be created with an array successfully
+        with a single input.
         """
-        SimulationResult(self.test_array, "probability_amplitude",
-                         inputs = self.test_inputs, 
-                         outputs = self.test_outputs)
+        SimulationResult(self.test_single_array, "probability_amplitude",
+                         inputs = self.test_single_inputs, 
+                         outputs = self.test_single_outputs)
+    
+    def test_multi_array_result_creation(self):
+        """
+        Checks that a result object can be created with an array successfully
+        with multiple inputs.
+        """
+        SimulationResult(self.test_multi_array, "probability_amplitude",
+                         inputs = self.test_multi_inputs, 
+                         outputs = self.test_multi_outputs)
+        
+    def test_single_input_retrival(self):
+        """
+        Checks that output can be indexed in case of single input.
+        """
+        r = SimulationResult(self.test_single_array, "probability_amplitude",
+                             inputs = self.test_single_inputs, 
+                             outputs = self.test_single_outputs)
+        assert r[State([1,0,1,0])] == 0.3
             
     def test_multi_input_retrival(self):
         """
         Confirms that result retrieval works correctly for multi input case.
         """
-        r = SimulationResult(self.test_array, "probability_amplitude", 
-                             inputs = self.test_inputs, 
-                             outputs = self.test_outputs)
+        r = SimulationResult(self.test_multi_array, "probability_amplitude", 
+                             inputs = self.test_multi_inputs, 
+                             outputs = self.test_multi_outputs)
         assert r[State([1,1,0,0])] == {State([1,0,1,0]): 0.3, 
                                        State([0,1,0,1]): 0.2, 
                                        State([0,0,2,0]): 0.1}
@@ -193,9 +218,9 @@ class TestSimulationResult:
         Confirms that result retrieval works correctly for multi input case,
         with both the input and output used to get a single value.
         """
-        r = SimulationResult(self.test_array, "probability_amplitude", 
-                             inputs = self.test_inputs, 
-                             outputs = self.test_outputs)
+        r = SimulationResult(self.test_multi_array, "probability_amplitude", 
+                             inputs = self.test_multi_inputs, 
+                             outputs = self.test_multi_outputs)
         assert r[State([1,1,0,0]), State([0,0,2,0])] == 0.1
             
     def test_multi_input_plot(self):
@@ -208,9 +233,27 @@ class TestSimulationResult:
         # https://stackoverflow.com/questions/71443540/intermittent-pytest-failures-complaining-about-missing-tcl-files-even-though-the
         original_backend = matplotlib.get_backend()
         matplotlib.use('Agg')
-        r = SimulationResult(self.test_array, "probability_amplitude", 
-                             inputs = self.test_inputs, 
-                             outputs = self.test_outputs)
+        r = SimulationResult(self.test_multi_array, "probability_amplitude", 
+                             inputs = self.test_multi_inputs, 
+                             outputs = self.test_multi_outputs)
+        # Test initial plot
+        r.plot()
+        plt.close()
+        # Test plot with conv_to_probability_option
+        r.plot(conv_to_probability=True)
+        plt.close()
+        # Reset backend after test
+        matplotlib.use(original_backend)
+        
+    def test_single_input_plot(self):
+        """
+        Confirm plotting is able to work without errors for single input case.
+        """
+        original_backend = matplotlib.get_backend()
+        matplotlib.use('Agg')
+        r = SimulationResult(self.test_single_array, "probability_amplitude", 
+                             inputs = self.test_single_inputs, 
+                             outputs = self.test_single_outputs)
         # Test initial plot
         r.plot()
         plt.close()
@@ -225,7 +268,64 @@ class TestSimulationResult:
         Check that miscellaneous additional kwargs can be provided in the 
         initial function call and that these are assigned to attributes.
         """
-        r = SimulationResult(self.test_array, "probability_amplitude", 
-                             inputs = self.test_inputs, 
-                             outputs = self.test_outputs, performance = 2.5)
+        r = SimulationResult(self.test_multi_array, "probability_amplitude", 
+                             inputs = self.test_multi_inputs, 
+                             outputs = self.test_multi_outputs, 
+                             performance = 2.5)
         assert r.performance == 2.5
+        
+    def test_single_print_outputs(self):
+        """
+        Confirms print outputs runs without raising an exception.
+        """
+        r = SimulationResult(self.test_single_array, "probability_amplitude", 
+                             inputs = self.test_single_inputs, 
+                             outputs = self.test_single_outputs)
+        r.print_outputs()
+        
+    def test_multi_print_outputs(self):
+        """
+        Confirms print outputs runs without raising an exception.
+        """
+        r = SimulationResult(self.test_multi_array, "probability_amplitude", 
+                             inputs = self.test_multi_inputs, 
+                             outputs = self.test_multi_outputs)
+        r.print_outputs()
+        
+    def test_single_display_as_dataframe(self):
+        """
+        Confirms display as dataframe runs without raising an exception.
+        """
+        r = SimulationResult(self.test_single_array, "probability_amplitude", 
+                             inputs = self.test_single_inputs, 
+                             outputs = self.test_single_outputs)
+        r.display_as_dataframe()
+        
+    def test_multi_display_as_dataframe(self):
+        """
+        Confirms display as dataframe runs without raising an exception.
+        """
+        r = SimulationResult(self.test_multi_array, "probability_amplitude", 
+                             inputs = self.test_multi_inputs, 
+                             outputs = self.test_multi_outputs)
+        r.display_as_dataframe()
+        
+    def test_single_display_as_dataframe_conv_to_probability(self):
+        """
+        Confirms display as dataframe runs without raising an exception, while
+        the conv_to_probability option is used.
+        """
+        r = SimulationResult(self.test_single_array, "probability_amplitude", 
+                             inputs = self.test_single_inputs, 
+                             outputs = self.test_single_outputs)
+        r.display_as_dataframe(conv_to_probability = True)
+        
+    def test_multi_display_as_dataframe_conv_to_probability(self):
+        """
+        Confirms display as dataframe runs without raising an exception, while
+        the conv_to_probability option is used.
+        """
+        r = SimulationResult(self.test_multi_array, "probability_amplitude", 
+                             inputs = self.test_multi_inputs, 
+                             outputs = self.test_multi_outputs)
+        r.display_as_dataframe(conv_to_probability = True)

--- a/tests/emulator/result_test.py
+++ b/tests/emulator/result_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from lightworks import State
-from lightworks.emulator.results import SamplingResult, SimulationResult 
+from lightworks.emulator.results import SamplingResult, SimulationResult
+from lightworks.emulator.utils import ResultCreationError 
 
 import pytest
 from numpy import array
@@ -38,6 +39,13 @@ class TestSamplingResult:
         """
         SamplingResult(self.test_dict, self.test_input)
     
+    def test_invalid_input_type(self):
+        """
+        Checks that input state is required to be a State object.
+        """
+        with pytest.raises(ResultCreationError):
+            SamplingResult(self.test_dict, self.test_input.s)
+    
     def test_single_input_retrival(self):
         """
         Confirms that result retrieval works correctly for single input case.
@@ -49,6 +57,13 @@ class TestSamplingResult:
         """Test return value from items method is correct."""
         r = SamplingResult(self.test_dict, self.test_input)
         assert r.items() == self.test_dict.items()
+        
+    def test_keys(self):
+        """
+        Checks that keys attribute returns a list of the output states. 
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        assert list(r.keys()) == r.outputs
     
     def test_threshold_mapping(self):
         """Check threshold mapping returns the correct result."""
@@ -83,6 +98,65 @@ class TestSamplingResult:
         """
         r = SamplingResult(self.test_dict, self.test_input, test_attr = 2.5)
         assert r.test_attr == 2.5
+        
+    def test_print_outputs(self):
+        """
+        Checks no exceptions are raised when the print outputs method is 
+        called.
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        r.print_outputs()
+        
+    def test_display_as_dataframe(self):
+        """
+        Checks that no exceptions are raised when display as Dataframe method
+        is called.
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        r.display_as_dataframe()
+        
+    def test_iterable(self):
+        """
+        Checks that SamplingResult acts an iterable which will run through all
+        outputs included in the result.
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        values = []
+        for i in r:
+            values.append(i)
+        assert values == r.outputs
+        
+    def test_str(self):
+        """
+        Tests that string return should be a string representation of the 
+        results dictionary
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        assert str(r) == str(r.dictionary)
+        
+    def test_get_items(self):
+        """
+        Checks that get item returns correct value for output.
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        assert r[State([1,0,0,1])] == 0.3
+        
+    def test_get_item_invalid_state(self):
+        """
+        Checks that get item raises a KeyError when output isn't found.
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        with pytest.raises(KeyError):
+            r[State([1,0,2,1])]
+        
+    @pytest.mark.parametrize("value", [[0,1,2,3], [0], ["|1,0,0,1>"]])
+    def test_get_item_invalid_type(self, value):
+        """
+        Checks that get item returns a ValueError when a non-state key is used.
+        """
+        r = SamplingResult(self.test_dict, self.test_input)
+        with pytest.raises(ValueError):
+            r[value]
             
 class TestSimulationResult:
     """Unit tests for SimulationResult object."""

--- a/tests/sdk/parameter_test.py
+++ b/tests/sdk/parameter_test.py
@@ -18,6 +18,8 @@ from lightworks import ParameterDictError
 
 import pytest
 
+from math import inf
+
 class TestParameter:
     """Unit tests to test functionality of Parameter objects."""
     
@@ -124,6 +126,26 @@ class TestParameter:
         """
         p = Parameter(1.2)
         assert str(p) == "1.2"
+    
+    @pytest.mark.parametrize("value", [1, 2.1, "test"])
+    def test_repr_return(self, value):
+        """
+        Checks Parameter value is contained within the value returned when repr
+        is used.
+        """
+        p = Parameter(value)
+        assert str(value) in repr(p)
+    
+    def test_label_in_repr_return(self):
+        """Checks label included in repr return."""
+        p = Parameter(1, label = "label")
+        assert "label" in repr(p)
+        
+    def test_bounds_in_repr_return(self):
+        """Checks bounds in repr return."""
+        p = Parameter(1, bounds = [0, 3])
+        assert str(p.min_bound) in repr(p)
+        assert str(p.max_bound) in repr(p)
         
 class TestParameterDict:
     """Unit tests to test functionality of ParameterDict objects."""
@@ -144,6 +166,15 @@ class TestParameterDict:
         pd = ParameterDict()
         pd["a"] = Parameter(1)
         assert isinstance(pd["a"], Parameter)
+        
+    def test_dict_invalid_param(self):
+        """
+        Confirms that a KeyError is raised when a parameter key does not exist.
+        """
+        pd = ParameterDict()
+        pd["a"] = Parameter(1)
+        with pytest.raises(KeyError):
+            pd["b"]
     
     def test_parameter_update(self):
         """Test updating of parameter through assigning new value to dict."""
@@ -234,3 +265,19 @@ class TestParameterDict:
             params.append(p)
         # Check lists is equivalent to params attribute
         assert params == pd.params
+        
+    def test_get_bounds(self):
+        """
+        Confirms that get bounds is able to identify bounds for parameter.
+        """
+        pd = ParameterDict()
+        pd["a"] = Parameter(1, bounds = [0, 2])
+        assert pd.get_bounds()["a"] == (0, 2)
+        
+    def test_get_bounds_no_bounds(self):
+        """
+        Confirms that get bounds replaces None bounds with +/- inf.
+        """
+        pd = ParameterDict()
+        pd["a"] = Parameter(1)
+        assert pd.get_bounds()["a"] == (-inf, inf)


### PR DESCRIPTION
Closes #31 through extension of unit testing to different components.

Also fixes issue where circuit get_all_params method would make copies of the Parameter objects, and removes deprecation warning for slicing.