### PR TITLE
Bug fix with state probability calculation and imperfect brightness

### DIFF
--- a/lightworks/emulator/simulation/probability_distribution.py
+++ b/lightworks/emulator/simulation/probability_distribution.py
@@ -50,11 +50,11 @@ class ProbabilityDistributionCalc:
                 else:
                     pdist = {s : p*prob for s, p in sub_dist.items()}
             else:
-                for s, p in  sub_dist:
+                for s, p in sub_dist.items():
                     if s in pdist:
-                        pdist += p*prob
+                        pdist[s] += p*prob
                     else:
-                        pdist = p*prob
+                        pdist[s] = p*prob
         # Calculate zero photon state probability afterwards
         total_prob = sum(pdist.values())
         if total_prob < 1 and circuit.loss_modes > 0:

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -578,7 +578,8 @@ class TestSamplerCalculationBackends:
         sampler = Sampler(circuit, State([1,1]), backend = backend,
                           source = Source(brightness = 0.8))
         N_sample = 100000
-        results = sampler.sample_N_inputs(N_sample, seed = 21)
+        results = sampler.sample_N_outputs(N_sample, seed = 21, 
+                                          min_detection = 2)
         assert len(results) == 2
         assert 0.49 < results[State([2,0])]/N_sample < 0.51
         assert 0.49 < results[State([0,2])]/N_sample < 0.51

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -566,3 +566,19 @@ class TestSamplerCalculationBackends:
                 full_s = s[0:1] + State([1]) + s[1:2] + State([0]) + s[2:]
                 # Check results are within 10%
                 assert pytest.approx(results[full_s], 0.1) == results2[s]
+                
+    def test_hom_imperfect_brightness(self, backend):
+        """
+        Checks sampling a basic 2 photon input onto a 50:50 beam splitter, 
+        which should undergo HOM, producing outputs of |2,0> and |0,2>. 
+        Includes imperfect brightness.
+        """
+        circuit = Circuit(2)
+        circuit.add_bs(0)
+        sampler = Sampler(circuit, State([1,1]), backend = backend,
+                          source = Source(brightness = 0.8))
+        N_sample = 100000
+        results = sampler.sample_N_inputs(N_sample, seed = 21)
+        assert len(results) == 2
+        assert 0.49 < results[State([2,0])]/N_sample < 0.51
+        assert 0.49 < results[State([0,2])]/N_sample < 0.51


### PR DESCRIPTION
Corrected an issue within the state_prob_calc method in which an error occurs when more than one input is used in the system (as a result of using an imperfect brightness).