### PR TITLE
Sampler parameter update bug fix

### DIFF
--- a/lightworks/__version.py
+++ b/lightworks/__version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/lightworks/emulator/simulation/probability_distribution.py
+++ b/lightworks/emulator/simulation/probability_distribution.py
@@ -50,11 +50,11 @@ class ProbabilityDistributionCalc:
                 else:
                     pdist = {s : p*prob for s, p in sub_dist.items()}
             else:
-                for s, p in  sub_dist:
+                for s, p in sub_dist.items():
                     if s in pdist:
-                        pdist += p*prob
+                        pdist[s] += p*prob
                     else:
-                        pdist = p*prob
+                        pdist[s] = p*prob
         # Calculate zero photon state probability afterwards
         total_prob = sum(pdist.values())
         if total_prob < 1 and circuit.loss_modes > 0:

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -406,7 +406,7 @@ class Sampler:
             # Treat arrays and other values differently
             if isinstance(i1, np.ndarray) and isinstance(i2, np.ndarray):
                 if i1.shape != i2.shape:
-                    return False
+                    return True
                 if not (i1 == i2).all():
                     return True
             else:

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -405,6 +405,8 @@ class Sampler:
                           self.__calculation_values):
             # Treat arrays and other values differently
             if isinstance(i1, np.ndarray) and isinstance(i2, np.ndarray):
+                if i1.shape != i2.shape:
+                    return False
                 if not (i1 == i2).all():
                     return True
             else:

--- a/tests/emulator/quicksampler_test.py
+++ b/tests/emulator/quicksampler_test.py
@@ -291,3 +291,20 @@ class TestQuickSampler:
         for s in p2:
             full_state = s[0:2] + State([0,1]) + s[2:]
             assert pytest.approx(p2[s]) == p1[full_state]
+            
+    def test_loss_variable_value(self):
+        """
+        Checks that QuickSampler is able to support number of required loss 
+        elements changing if these are part of a parameterized circuits.
+        """
+        loss = Parameter(0)
+        circuit = Circuit(4)
+        circuit.add_bs(0, loss = loss)
+        circuit.add_bs(2, loss = loss)
+        circuit.add_bs(1, loss = loss)
+        # Initially sample
+        sampler = QuickSampler(circuit, State([1,0,1,0]))
+        results = sampler.sample_N_outputs(10000)
+        # Add loss and resample
+        loss.set(1)
+        results = sampler.sample_N_outputs(10000)

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -583,3 +583,20 @@ class TestSamplerCalculationBackends:
         assert len(results) == 2
         assert 0.49 < results[State([2,0])]/N_sample < 0.51
         assert 0.49 < results[State([0,2])]/N_sample < 0.51
+        
+    def test_loss_variable_value(self, backend):
+        """
+        Checks that Sampler is able to support number of required loss elements
+        changing if these are part of a parameterized circuits.
+        """
+        loss = Parameter(0)
+        circuit = Circuit(4)
+        circuit.add_bs(0, loss = loss)
+        circuit.add_bs(2, loss = loss)
+        circuit.add_bs(1, loss = loss)
+        # Initially sample
+        sampler = Sampler(circuit, State([1,0,1,0]), backend = backend)
+        results = sampler.sample_N_inputs(10000)
+        # Add loss and resample
+        loss.set(1)
+        results = sampler.sample_N_inputs(10000)

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -566,3 +566,20 @@ class TestSamplerCalculationBackends:
                 full_s = s[0:1] + State([1]) + s[1:2] + State([0]) + s[2:]
                 # Check results are within 10%
                 assert pytest.approx(results[full_s], 0.1) == results2[s]
+                
+    def test_hom_imperfect_brightness(self, backend):
+        """
+        Checks sampling a basic 2 photon input onto a 50:50 beam splitter, 
+        which should undergo HOM, producing outputs of |2,0> and |0,2>. 
+        Includes imperfect brightness.
+        """
+        circuit = Circuit(2)
+        circuit.add_bs(0)
+        sampler = Sampler(circuit, State([1,1]), backend = backend,
+                          source = Source(brightness = 0.8))
+        N_sample = 100000
+        results = sampler.sample_N_outputs(N_sample, seed = 21, 
+                                          min_detection = 2)
+        assert len(results) == 2
+        assert 0.49 < results[State([2,0])]/N_sample < 0.51
+        assert 0.49 < results[State([0,2])]/N_sample < 0.51


### PR DESCRIPTION
Fixed an issue which occurred when the number of loss elements in a circuit changes (usually due to parameters being used to adjust loss value to 0, as this changes the unitary size), where this would cause an exception to be raised.

This was fixed by adding a condition that the arrays for comparison should be the same size otherwise it is assumed that a parameter updated has occurred and the Sampler probability distribution is updated.