### PR TITLE
Add ruff pytest checking

### DIFF
--- a/lightworks/emulator/results/sampling_result.py
+++ b/lightworks/emulator/results/sampling_result.py
@@ -218,7 +218,7 @@ class SamplingResult:
         for ostate, p in self.dictionary.items():
             to_print += str(ostate) + " : " + str(p) + ", "
         to_print = to_print[:-2]
-        print(to_print)
+        print(to_print)  # noqa: T201
 
         return
 

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -324,7 +324,7 @@ class SimulationResult:
                     if abs(p.real) > 0 or abs(p.imag) > 0:
                         to_print += str(p) + "*" + str(ostate) + " + "
             to_print = to_print[:-2]
-            print(to_print)
+            print(to_print)  # noqa: T201
 
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ preview = true
 select = [
     "E", "F", "W", "N", "D", "B", "CPY", "TRY", "PLE", "PLW", "YTT", "ANN", "S",
     "Q", "SIM", "ARG", "PERF", "I", "EM102", "EM103", "RET", "FURB148", 
-    "FURB168", "RUF", "BLE", "UP", "NPY"
+    "FURB168", "RUF", "BLE", "UP", "NPY", "T20", "PT"
 ]
 fixable = ["ALL"]
 ignore = [
@@ -68,6 +68,7 @@ ignore = [
     "D407",
     "D412",
     "D415",
+    "PT011",
     "RUF022",
     "S311",
     "SIM102",
@@ -84,3 +85,7 @@ line-ending = "auto"
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["PERF", "ANN", "S101"]
 "__init__.py" = ["F401", "F403"]
+
+[tool.ruff.lint.flake8-pytest-style]
+parametrize-names-type = "tuple"
+parametrize-values-row-type = "tuple"

--- a/tests/emulator/result_test.py
+++ b/tests/emulator/result_test.py
@@ -171,8 +171,7 @@ class TestSamplingResult:
 class TestSimulationResult:
     """Unit tests for SimulationResult object."""
 
-    @pytest.fixture(autouse=True)
-    def setup_data(self) -> None:
+    def setup_method(self) -> None:
         """Create a variety of useful pieces of data for testing."""
         # Single input
         self.test_single_inputs = [State([1, 1, 0, 0])]
@@ -257,12 +256,12 @@ class TestSimulationResult:
         assert r[State([1, 1, 0, 0]), State([1, 0, 3, 0])] == 0.1
 
     @pytest.mark.parametrize(
-        "conv_to_probability,rtype",
+        ("conv_to_probability", "rtype"),
         [
-            [True, "probability_amplitude"],
-            [False, "probability_amplitude"],
-            [True, "probability"],
-            [False, "probability"],
+            (True, "probability_amplitude"),
+            (False, "probability_amplitude"),
+            (True, "probability"),
+            (False, "probability"),
         ],
     )
     def test_multi_input_plot(self, conv_to_probability, rtype):
@@ -288,12 +287,12 @@ class TestSimulationResult:
         matplotlib.use(original_backend)
 
     @pytest.mark.parametrize(
-        "conv_to_probability,rtype",
+        ("conv_to_probability", "rtype"),
         [
-            [True, "probability_amplitude"],
-            [False, "probability_amplitude"],
-            [True, "probability"],
-            [False, "probability"],
+            (True, "probability_amplitude"),
+            (False, "probability_amplitude"),
+            (True, "probability"),
+            (False, "probability"),
         ],
     )
     def test_single_input_plot(self, conv_to_probability, rtype):

--- a/tests/emulator/source_test.py
+++ b/tests/emulator/source_test.py
@@ -83,7 +83,7 @@ class TestSource:
         assert len(stats) == 89
 
     @pytest.mark.parametrize(
-        "value,error",
+        ("value", "error"),
         [
             (True, TypeError),
             ("0.7", TypeError),
@@ -100,7 +100,7 @@ class TestSource:
             source.purity = value
 
     @pytest.mark.parametrize(
-        "value,error",
+        ("value", "error"),
         [
             (True, TypeError),
             ("0.5", TypeError),
@@ -117,7 +117,7 @@ class TestSource:
             source.brightness = value
 
     @pytest.mark.parametrize(
-        "value,error",
+        ("value", "error"),
         [
             (True, TypeError),
             ("0.5", TypeError),
@@ -135,7 +135,7 @@ class TestSource:
             source.indistinguishability = value
 
     @pytest.mark.parametrize(
-        "value,error",
+        ("value", "error"),
         [
             (True, TypeError),
             ("0.5", TypeError),

--- a/tests/qubit/gate_test.py
+++ b/tests/qubit/gate_test.py
@@ -270,7 +270,7 @@ class TestThreeQubitGates:
         assert pytest.approx(abs(amp) ** 2, 1e-6) == 1 / 72
 
     @pytest.mark.parametrize(
-        "target,swap_indices", [[0, (5, 7)], [1, (6, 7)], [2, (3, 7)]]
+        ("target", "swap_indices"), [(0, (5, 7)), (1, (6, 7)), (2, (3, 7))]
     )
     def test_CCNOT(self, target, swap_indices):
         """

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -299,7 +299,10 @@ class TestCircuit:
             if spec[0] == "bs":
                 # Check it acts on adjacent modes, otherwise fail
                 if spec[1][0] != spec[1][1] - 1:
-                    pytest.fail()
+                    pytest.fail(
+                        "Beam splitter which acts on non-adjacent modes found "
+                        "in circuit spec."
+                    )
 
     def test_remove_non_adj_bs_equivalence(self):
         """
@@ -658,8 +661,8 @@ class TestCircuit:
         assert circuit.input_modes == n - 2
 
     @pytest.mark.parametrize(
-        "initial_modes,final_modes",
-        [[(0,), (0, 2)], [(2,), (5, 6)], [(2, 3), (5, 6)], [(0, 2), (0, 5)]],
+        ("initial_modes", "final_modes"),
+        [((0,), (0, 2)), ((2,), (5, 6)), ((2, 3), (5, 6)), ((0, 2), (0, 5))],
     )
     def test_bs_correct_modes(self, initial_modes, final_modes):
         """


### PR DESCRIPTION
Adds the ruff PT rules for checking pytest unit tests and T20 for disallowing print statements in the code.

Fixes have been implemented where issues were raised by ruff.