### PR TITLE
Expansion of ruff rules

### DIFF
--- a/lightworks/emulator/backend/permanent.py
+++ b/lightworks/emulator/backend/permanent.py
@@ -53,7 +53,7 @@ def partition(
     # Construct the matrix of indices for the partition
     x, y = [], []
     for i in range(n_modes):
-        x += [i] * out_state[i]  # type: ignore
-        y += [i] * in_state[i]  # type: ignore
+        x += [i] * out_state[i]
+        y += [i] * in_state[i]
     # Construct the new matrix with dimension n, where n is photon number
     return unitary[np.ix_(x, y)]

--- a/lightworks/emulator/backend/slos.py
+++ b/lightworks/emulator/backend/slos.py
@@ -30,11 +30,7 @@ class SLOS:
         Performs calculation of full probability distribution given a unitary
         matrix and input state.
         """
-        p = [  # type: ignore
-            m
-            for m, n in enumerate(input_state)  # type: ignore
-            for _i in range(n)
-        ]
+        p = [m for m, n in enumerate(input_state) for _i in range(n)]
         n_modes = unitary.shape[0]
         input = {tuple(n_modes * [0]): 1.0}  # N-mode vacuum state
 

--- a/lightworks/emulator/components/detector.py
+++ b/lightworks/emulator/components/detector.py
@@ -118,7 +118,7 @@ class Detector:
         if self.efficiency == 1 and self.p_dark == 0 and self.photon_counting:
             return in_state
         # Convert state to list
-        output = [i for i in in_state]  # type: ignore
+        output = list(in_state)  # type: ignore
         # Account for efficiency
         if self.efficiency < 1:
             for mode, n in enumerate(in_state):  # type: ignore

--- a/lightworks/emulator/components/detector.py
+++ b/lightworks/emulator/components/detector.py
@@ -118,10 +118,10 @@ class Detector:
         if self.efficiency == 1 and self.p_dark == 0 and self.photon_counting:
             return in_state
         # Convert state to list
-        output = list(in_state)  # type: ignore
+        output = list(in_state)
         # Account for efficiency
         if self.efficiency < 1:
-            for mode, n in enumerate(in_state):  # type: ignore
+            for mode, n in enumerate(in_state):
                 for _i in range(n):
                     if random() > self.efficiency:
                         output[mode] -= 1
@@ -136,7 +136,7 @@ class Detector:
 
         return State(output)
 
-    def _set_random_seed(self, r_seed: int | float | None) -> None:
+    def _set_random_seed(self, r_seed: float | None) -> None:
         """
         Set the random seed for the detector to produce repeatable results.
         """

--- a/lightworks/emulator/components/source.py
+++ b/lightworks/emulator/components/source.py
@@ -193,7 +193,7 @@ class Source:
         n_modes = len(state)
         stats: list[tuple[float, list[int]]] = []
         # Loop over each mode
-        for mode, count in enumerate(state):  # type: ignore
+        for mode, count in enumerate(state):
             if not count:
                 continue
             for _i in range(count):
@@ -296,7 +296,7 @@ class Source:
         to_group, to_skip = group_empty_modes(state)
         input_dist: dict[AnnotatedState, float] = {}
         # Loop over each mode and find distribution
-        for i, n in enumerate(state):  # type: ignore
+        for i, n in enumerate(state):
             if i in to_skip:
                 continue
             # Added groups of empty photons
@@ -404,7 +404,7 @@ def group_empty_modes(state: State) -> tuple[dict, list]:
     to_group = {}
     to_skip = []
     # Loop over each mode in the state
-    for i, s in enumerate(state):  # type: ignore
+    for i, s in enumerate(state):
         # Skip any modes already grouped or the last mode
         if i in to_skip or i == len(state) - 1:
             continue

--- a/lightworks/emulator/components/source.py
+++ b/lightworks/emulator/components/source.py
@@ -410,7 +410,7 @@ def group_empty_modes(state: State) -> tuple[dict, list]:
             continue
         if s == 0:
             # If only a single empty mode then skip
-            if state[i + 1] > 0:  # type: ignore
+            if state[i + 1] > 0:
                 continue
             # Find how many empty modes there are
             n = 1

--- a/lightworks/emulator/results/sampling_result.py
+++ b/lightworks/emulator/results/sampling_result.py
@@ -259,5 +259,5 @@ class SamplingResult:
         # Convert array to floats when not non complex results used
         data = data.astype(int)
         # Create dataframe
-        df = pd.DataFrame(data, index=out_strings, columns=in_strings)
-        return df.transpose()
+        results = pd.DataFrame(data, index=out_strings, columns=in_strings)
+        return results.transpose()

--- a/lightworks/emulator/results/sampling_result.py
+++ b/lightworks/emulator/results/sampling_result.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Iterator
 
 import matplotlib.figure
 import matplotlib.pyplot as plt
@@ -79,7 +79,7 @@ class SamplingResult:
     def __len__(self) -> int:
         return len(self.dictionary)
 
-    def __iter__(self) -> Iterable:
+    def __iter__(self) -> Iterator:
         """Iterable to allow to do 'for output in SamplingResult'."""
         yield from self.dictionary
 
@@ -122,7 +122,7 @@ class SamplingResult:
         for out_state, val in self.dictionary.items():
             new_s = State([1 if s >= 1 else 0 for s in out_state])
             if invert:
-                new_s = State([1 - s for s in new_s])  # type: ignore
+                new_s = State([1 - s for s in new_s])
             if new_s in mapped_result:
                 mapped_result[new_s] += val
             else:

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Iterable
+from typing import Any, Iterator
 
 import matplotlib.figure
 import matplotlib.pyplot as plt
@@ -158,7 +158,7 @@ class SimulationResult:
     def __str__(self) -> str:
         return str(self.dictionary)
 
-    def __iter__(self) -> Iterable:
+    def __iter__(self) -> Iterator:
         """Iterable to allow to do 'for input in SimulationResult'."""
         yield from self.dictionary
 
@@ -191,7 +191,7 @@ class SimulationResult:
             for out_state, val in self.dictionary[in_state].items():
                 new_s = State([1 if s >= 1 else 0 for s in out_state])
                 if invert:
-                    new_s = State([1 - s for s in new_s])  # type: ignore
+                    new_s = State([1 - s for s in new_s])
                 if new_s in mapped_result[in_state]:
                     mapped_result[in_state][new_s] += val
                 else:

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -413,8 +413,8 @@ class SimulationResult:
         # Otherwise create two plots
         fig, axes = plt.subplots(1, 2, figsize=(20, 6))
         axes = np.array(axes)
-        vmin = min([op(self.array).min() for op in [np.real, np.imag]])
-        vmax = min([op(self.array).max() for op in [np.real, np.imag]])
+        vmin = min(op(self.array).min() for op in [np.real, np.imag])
+        vmax = min(op(self.array).max() for op in [np.real, np.imag])
         im = axes[0].imshow(np.real(self.array), vmin=vmin, vmax=vmax)
         axes[0].set_title("real(result)")
         axes[1].imshow(np.imag(self.array), vmin=vmin, vmax=vmax)

--- a/lightworks/emulator/simulation/analyzer.py
+++ b/lightworks/emulator/simulation/analyzer.py
@@ -274,7 +274,7 @@ class Analyzer:
         # Combine all n < n_in for lossy case
         else:
             outputs = []
-            for n in range(0, n_photons + 1):
+            for n in range(n_photons + 1):
                 outputs += fock_basis(n_modes, n)
         # Filter outputs according to post selection and add heralded photons
         filtered_outputs = []

--- a/lightworks/emulator/simulation/probability_distribution.py
+++ b/lightworks/emulator/simulation/probability_distribution.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 from multimethod import multimethod
 
 from ...sdk.circuit.circuit_compiler import CompiledCircuit
@@ -101,12 +103,12 @@ def annotated_state_pdist_calc(
     for state in inputs:
         # Find all labels in a given state
         all_labels = []
-        for mode in state:  # type: ignore
+        for mode in state:
             all_labels += mode
         # For all labels break them down into the corresponding states
         if all_labels:
             results = {lab: [0] * circuit.n_modes for lab in all_labels}
-            for i, mode in enumerate(state):  # type: ignore
+            for i, mode in enumerate(state):
                 for m in mode:
                     results[m][i] += 1
             states = [State(s) for s in results.values()]
@@ -117,7 +119,7 @@ def annotated_state_pdist_calc(
         input_combinations[state] = states
     # For each of the unique inputs then need to work out the probability
     # distribution
-    unique_results = {}
+    unique_results: dict[Any, Any] = {}
     for in_state in unique_inputs:
         # Calculate sub distribution and store
         unique_results[in_state[: circuit.n_modes]] = (
@@ -126,7 +128,7 @@ def annotated_state_pdist_calc(
 
     # Pre-calculate dictionary items to improve speed
     for r, pdist in unique_results.items():
-        unique_results[r] = list(pdist.items())  # type: ignore
+        unique_results[r] = list(pdist.items())
     # Then combine the results above to work out the true output
     # probability for the inputs.
     stats_dict = {}

--- a/lightworks/emulator/simulation/probability_distribution.py
+++ b/lightworks/emulator/simulation/probability_distribution.py
@@ -119,7 +119,7 @@ def annotated_state_pdist_calc(
         input_combinations[state] = states
     # For each of the unique inputs then need to work out the probability
     # distribution
-    unique_results: dict[Any, Any] = {}
+    unique_results: dict[State, Any] = {}
     for in_state in unique_inputs:
         # Calculate sub distribution and store
         unique_results[in_state[: circuit.n_modes]] = (

--- a/lightworks/emulator/state/annotated_state.py
+++ b/lightworks/emulator/state/annotated_state.py
@@ -17,7 +17,7 @@ A custom state datatype, which is created for storing annotated state details.
 It is not intended that this class will be ordinarily accessible to users.
 """
 
-from typing import Any, Iterable, Union
+from typing import Any, Iterator, Union
 
 from ..utils import AnnotatedStateError, annotated_state_to_string
 
@@ -93,7 +93,7 @@ class AnnotatedState:
             raise TypeError("Addition only supported between annotated states.")
         return AnnotatedState(self.__s + value.__s)
 
-    def __eq__(self, value: Any) -> bool:
+    def __eq__(self, value: object) -> bool:
         if not isinstance(value, AnnotatedState):
             return False
         return self.__s == value.__s
@@ -109,7 +109,7 @@ class AnnotatedState:
             "AnnotatedState object does not support item assignment."
         )
 
-    def __iter__(self) -> Iterable[list]:
+    def __iter__(self) -> Iterator[list]:
         yield from self.s
 
     def __getitem__(

--- a/lightworks/emulator/state/annotated_state.py
+++ b/lightworks/emulator/state/annotated_state.py
@@ -17,7 +17,7 @@ A custom state datatype, which is created for storing annotated state details.
 It is not intended that this class will be ordinarily accessible to users.
 """
 
-from typing import Any, Iterator, Union
+from typing import Any, Iterator, Union, overload
 
 from ..utils import AnnotatedStateError, annotated_state_to_string
 
@@ -111,6 +111,12 @@ class AnnotatedState:
 
     def __iter__(self) -> Iterator[list]:
         yield from self.s
+
+    @overload
+    def __getitem__(self, indices: int) -> list: ...
+
+    @overload
+    def __getitem__(self, indices: slice) -> "AnnotatedState": ...
 
     def __getitem__(
         self, indices: int | slice

--- a/lightworks/emulator/state/annotated_state.py
+++ b/lightworks/emulator/state/annotated_state.py
@@ -49,12 +49,12 @@ class AnnotatedState:
     @property
     def n_photons(self) -> int:
         """Returns the number of photons in a State."""
-        return sum([len(s) for s in self.__s])
+        return sum(len(s) for s in self.__s)
 
     @property
     def s(self) -> list[list[int]]:
         """Returns list representation of State."""
-        return [[j for j in i] for i in self.__s]
+        return [list(i) for i in self.__s]
 
     @s.setter
     def s(self, value: Any) -> None:  # noqa: ARG002

--- a/lightworks/interferometers/dists/constant.py
+++ b/lightworks/interferometers/dists/constant.py
@@ -26,7 +26,7 @@ class Constant(Distribution):
 
     """
 
-    def __init__(self, value: int | float) -> None:
+    def __init__(self, value: float) -> None:
         is_number(value)
         self._value = value
 

--- a/lightworks/interferometers/dists/gaussian.py
+++ b/lightworks/interferometers/dists/gaussian.py
@@ -47,10 +47,10 @@ class Gaussian(Distribution):
 
     def __init__(
         self,
-        center: int | float,
-        deviation: int | float,
-        min_value: int | float | None = None,
-        max_value: int | float | None = None,
+        center: float,
+        deviation: float,
+        min_value: float | None = None,
+        max_value: float | None = None,
     ) -> None:
         # Assign min\max to +/i infinity if None
         if min_value is None:

--- a/lightworks/interferometers/dists/top_hat.py
+++ b/lightworks/interferometers/dists/top_hat.py
@@ -30,7 +30,7 @@ class TopHat(Distribution):
 
     """
 
-    def __init__(self, min_value: int | float, max_value: int | float) -> None:
+    def __init__(self, min_value: float, max_value: float) -> None:
         # Type check all values
         is_number([min_value, max_value])
         # Then check min and max values are valid

--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -411,13 +411,11 @@ class Circuit:
 
         """
         if modes is None:
-            modes = [
-                i for i in range(self.n_modes - len(self.__internal_modes))
-            ]
+            modes = list(range(self.n_modes - len(self.__internal_modes)))
         modes = [self._map_mode(i) for i in modes]
         for m in modes:
             self._mode_in_range(m)
-        self.__circuit_spec.append(["barrier", tuple([modes])])
+        self.__circuit_spec.append(["barrier", (modes,)])
 
     def mode_swaps(self, swaps: dict) -> None:
         """
@@ -438,8 +436,8 @@ class Circuit:
             self._map_mode(mi): self._map_mode(mo) for mi, mo in swaps.items()
         }
         # Perform some error checking steps
-        in_modes = sorted(list(swaps.keys()))
-        out_modes = sorted(list(swaps.values()))
+        in_modes = sorted(swaps.keys())
+        out_modes = sorted(swaps.values())
         if in_modes != out_modes:
             raise ValueError(
                 "Mode swaps not complete, dictionary keys and values should "

--- a/lightworks/sdk/circuit/circuit_compiler.py
+++ b/lightworks/sdk/circuit/circuit_compiler.py
@@ -338,8 +338,8 @@ class CompiledCircuit:
             raise TypeError("Mode swaps data should be a dictionary.")
         for m in list(swaps.keys()) + list(swaps.values()):
             self._mode_in_range(m)
-        in_modes = sorted(list(swaps.keys()))
-        out_modes = sorted(list(swaps.values()))
+        in_modes = sorted(swaps.keys())
+        out_modes = sorted(swaps.values())
         if in_modes != out_modes:
             raise ValueError(
                 "Mode swaps not complete, dictionary keys and values should "

--- a/lightworks/sdk/circuit/circuit_utils.py
+++ b/lightworks/sdk/circuit/circuit_utils.py
@@ -38,7 +38,7 @@ def unpack_circuit_spec(circuit_spec: list) -> list:
         list : The processed circuit spec.
 
     """
-    new_spec = [c for c in circuit_spec]
+    new_spec = list(circuit_spec)
     components = [i[0] for i in circuit_spec]
     while "group" in components:
         temp_spec = []
@@ -77,7 +77,7 @@ def add_modes_to_circuit_spec(circuit_spec: list, mode: int) -> list:
             params[1] += mode
         elif c == "barrier":
             params = [p + mode for p in params[0]]
-            params = tuple([params])
+            params = (params,)
         elif c == "mode_swaps":
             params[0] = {k + mode: v + mode for k, v in params[0].items()}
         elif c == "group":
@@ -113,7 +113,7 @@ def add_empty_mode_to_circuit_spec(circuit_spec: list, mode: int) -> list:
             params[1] += 1 if params[1] >= mode else 0
         elif c == "barrier":
             params = [p + 1 if p >= mode else p for p in params[0]]
-            params = tuple([params])
+            params = (params,)
         elif c == "mode_swaps":
             swaps = {}
             for k, v in params[0].items():
@@ -190,7 +190,7 @@ def convert_non_adj_beamsplitters(spec: list) -> list:
             swaps = {v: k for k, v in swaps.items()}
             new_spec.append(["mode_swaps", (swaps, None)])
         elif s[0] == "group":
-            new_s1 = [si for si in s[1]]
+            new_s1 = list(s[1])
             new_s1[0] = convert_non_adj_beamsplitters(s[1][0])
             s = [s[0], tuple(new_s1)]
             new_spec.append(s)

--- a/lightworks/sdk/circuit/parameters.py
+++ b/lightworks/sdk/circuit/parameters.py
@@ -83,19 +83,19 @@ class Parameter:
         return self.__min_bound
 
     @min_bound.setter
-    def min_bound(self, __value: Any) -> None:
-        if __value is not None:
+    def min_bound(self, value: Any) -> None:
+        if value is not None:
             if not isnumeric(self.__value):
                 raise ParameterBoundsError(
                     "Bounds cannot be set for non-numeric parameters."
                 )
-            if not isnumeric(__value):
+            if not isnumeric(value):
                 raise ParameterBoundsError("Bound should be numeric or None.")
-            if self.__value < __value:
+            if self.__value < value:
                 raise ParameterBoundsError(
                     "Current parameter value is below new minimum bound."
                 )
-        self.__min_bound = __value
+        self.__min_bound = value
 
     @property
     def max_bound(self) -> Number | None:
@@ -103,19 +103,19 @@ class Parameter:
         return self.__max_bound
 
     @max_bound.setter
-    def max_bound(self, __value: Any) -> None:
-        if __value is not None:
+    def max_bound(self, value: Any) -> None:
+        if value is not None:
             if not isnumeric(self.__value):
                 raise ParameterBoundsError(
                     "Bounds cannot be set for non-numeric parameters."
                 )
-            if not isnumeric(__value):
+            if not isnumeric(value):
                 raise ParameterBoundsError("Bound should be numeric or None.")
-            if self.__value > __value:
+            if self.__value > value:
                 raise ParameterBoundsError(
                     "Current parameter value is above new maximum bound."
                 )
-        self.__max_bound = __value
+        self.__max_bound = value
 
     def __str__(self) -> str:
         return str(self.__value)

--- a/lightworks/sdk/optimisation/optimisation.py
+++ b/lightworks/sdk/optimisation/optimisation.py
@@ -225,9 +225,7 @@ class Optimisation:
         if self.parameters.has_bounds():
             bounds = list(self.parameters.get_bounds().values())
         res = minimize(self._fom, x0=self.__x0, bounds=bounds)
-        self.__opt_results = {
-            p: x for p, x in zip(self.parameters.keys(), res.x)
-        }
+        self.__opt_results = dict(zip(self.parameters.keys(), res.x))
         return self.__opt_results
 
     def scipy_basinhopping_optimise(
@@ -262,9 +260,7 @@ class Optimisation:
                 "Bounds not supported by basinhopping optimise method."
             )
         res = basinhopping(self._fom, x0=self.__x0, niter=n_iter)
-        self.__opt_results = {
-            p: x for p, x in zip(self.parameters.keys(), res.x)
-        }
+        self.__opt_results = dict(zip(self.parameters.keys(), res.x))
         return self.__opt_results
 
     def bayesian_optimise(
@@ -344,9 +340,7 @@ class Optimisation:
         objective = zoopt.Objective(self._fom_zoopt, dim)
         parameter = zoopt.Parameter(budget=budget)
         sol = zoopt.Opt.min(objective, parameter)
-        self.__opt_results = {
-            p: x for p, x in zip(self.parameters.keys(), sol.get_x())
-        }
+        self.__opt_results = dict(zip(self.parameters.keys(), sol.get_x()))
         return self.__opt_results
 
     def get_optimal_circuit(self) -> Circuit:

--- a/lightworks/sdk/state/state.py
+++ b/lightworks/sdk/state/state.py
@@ -18,7 +18,7 @@ emulator much easier to work with.
 """
 
 from copy import copy
-from typing import Any, Iterator, Union
+from typing import Any, Iterator, Union, overload
 
 from ..utils.exceptions import StateError
 from .state_utils import state_to_string
@@ -116,6 +116,12 @@ class State:
 
     def __setitem__(self, key: Any, value: Any) -> None:
         raise StateError("State object does not support item assignment.")
+
+    @overload
+    def __getitem__(self, indices: int) -> int: ...
+
+    @overload
+    def __getitem__(self, indices: slice) -> "State": ...
 
     def __getitem__(self, indices: slice | int) -> Union[int, "State"]:
         if isinstance(indices, slice):

--- a/lightworks/sdk/state/state.py
+++ b/lightworks/sdk/state/state.py
@@ -18,7 +18,7 @@ emulator much easier to work with.
 """
 
 from copy import copy
-from typing import Any, Iterable, Union
+from typing import Any, Iterator, Union
 
 from ..utils.exceptions import StateError
 from .state_utils import state_to_string
@@ -100,7 +100,7 @@ class State:
             raise TypeError("Addition only supported between states.")
         return State(self.__s + value.__s)
 
-    def __eq__(self, value: Any) -> bool:
+    def __eq__(self, value: object) -> bool:
         if not isinstance(value, State):
             return False
         return self.__s == value.s
@@ -111,7 +111,7 @@ class State:
     def __len__(self) -> int:
         return self.n_modes
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         yield from self.s
 
     def __setitem__(self, key: Any, value: Any) -> None:

--- a/lightworks/sdk/utils/heralding_utils.py
+++ b/lightworks/sdk/utils/heralding_utils.py
@@ -65,7 +65,7 @@ def remove_heralds_from_state(state: State | list, herald_modes: list) -> list:
 
     """
     # Remove modes in reverse order so mode locations do not change
-    to_remove = reversed(sorted(herald_modes))
+    to_remove = sorted(herald_modes, reverse=True)
     # Get list version of state
     new_s = state.s if isinstance(state, State) else copy(state)
     # Then sequentially pop modes

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -94,7 +94,7 @@ class DrawCircuitSVG:
                 full_mode_labels.append("-")
         mode_labels = full_mode_labels
         # Adjust canvas size for long labels
-        max_len = max([len(m) for m in mode_labels])
+        max_len = max(len(m) for m in mode_labels)
         if max_len > 4:
             init_length += (max_len - 4) * 17.5
         for m, label in enumerate(mode_labels):
@@ -473,7 +473,7 @@ class DrawCircuitSVG:
         Add a barrier which will separate different parts of the circuit. This
         is applied to the provided modes.
         """
-        max_loc = max([self.x_locations[m] for m in modes])
+        max_loc = max(self.x_locations[m] for m in modes)
         for m in modes:
             loc = self.x_locations[m]
             if loc < max_loc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ preview = true
 select = [
     "E", "F", "W", "N", "D", "B", "CPY", "TRY", "PLE", "PLW", "YTT", "ANN", "S",
     "Q", "SIM", "ARG", "PERF", "I", "EM102", "EM103", "RET", "FURB148", 
-    "FURB168", "RUF", "BLE", "UP", "NPY", "T20", "PT", "C4", "A", "PYI"
+    "FURB168", "RUF", "BLE", "UP", "NPY", "T20", "PT", "C4", "A", "PYI", "PIE",
+    "SLOT", "PD"
 ]
 fixable = ["ALL"]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ preview = true
 select = [
     "E", "F", "W", "N", "D", "B", "CPY", "TRY", "PLE", "PLW", "YTT", "ANN", "S",
     "Q", "SIM", "ARG", "PERF", "I", "EM102", "EM103", "RET", "FURB148", 
-    "FURB168", "RUF", "BLE", "UP", "NPY", "T20", "PT", "C4"
+    "FURB168", "RUF", "BLE", "UP", "NPY", "T20", "PT", "C4", "A", "PYI"
 ]
 fixable = ["ALL"]
 ignore = [
@@ -89,3 +89,6 @@ line-ending = "auto"
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-names-type = "tuple"
 parametrize-values-row-type = "tuple"
+
+[tool.ruff.lint.flake8-builtins]
+builtins-ignorelist = ["input"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ preview = true
 select = [
     "E", "F", "W", "N", "D", "B", "CPY", "TRY", "PLE", "PLW", "YTT", "ANN", "S",
     "Q", "SIM", "ARG", "PERF", "I", "EM102", "EM103", "RET", "FURB148", 
-    "FURB168", "RUF", "BLE", "UP", "NPY", "T20", "PT"
+    "FURB168", "RUF", "BLE", "UP", "NPY", "T20", "PT", "C4"
 ]
 fixable = ["ALL"]
 ignore = [

--- a/tests/sdk/util_test.py
+++ b/tests/sdk/util_test.py
@@ -176,7 +176,7 @@ class TestUtils:
         Checks that add heralds to state does not modify the original state.
         """
         s = [randint(0, 5) for i in range(10)]
-        s_copy = [i for i in s]
+        s_copy = list(s)  # Creates copy of list
         add_heralds_to_state(s, {6: 7, 1: 6})
         assert s == s_copy
 


### PR DESCRIPTION
Add the following collections of ruff rules: C4, PYI, PIE, SLOT, PD, and fixed code where required.

Also added type overloading to getitem in State and AnnotatedState, which allows for mypy to correctly interpret types here. As a result, a lot of instances where mypy was ignored could be removed.