### PR TITLE
Circuit spec rework

### DIFF
--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
 
 from ..utils import (
     CircuitCompilationError,
-    DisplayError,
     ModeRangeError,
 )
 from ..visualisation import Display
@@ -41,8 +40,17 @@ from .circuit_utils import (
     check_loss,
     compress_mode_swaps,
     convert_non_adj_beamsplitters,
-    display_loss_check,
     unpack_circuit_spec,
+)
+from .components import (
+    Barrier,
+    BeamSplitter,
+    Component,
+    Group,
+    Loss,
+    ModeSwaps,
+    PhaseShifter,
+    UnitaryMatrix,
 )
 from .parameters import Parameter
 
@@ -152,11 +160,6 @@ class Circuit:
         }
 
     @property
-    def _display_spec(self) -> list:
-        """The display spec for the circuit."""
-        return self._get_display_spec()
-
-    @property
     def _internal_modes(self) -> list:
         return self.__internal_modes
 
@@ -221,8 +224,8 @@ class Circuit:
         if name is None:
             spec = circuit.__circuit_spec
             # Special case where name is retrieved from previous group
-            if len(spec) == 1 and spec[0][0] == "group":
-                name = spec[0][1][1]
+            if len(spec) == 1 and isinstance(spec[0], Group):
+                name = spec[0].name
             # Otherwise default to circuit
             else:
                 name = "Circuit"
@@ -274,7 +277,7 @@ class Circuit:
                 current_mode += 1
         # Skip for cases where swaps do not alter mode structure
         if list(swaps.keys()) != list(swaps.values()):
-            spec.append(["mode_swaps", (swaps, None)])
+            spec.append(ModeSwaps(swaps))
         # Update heralds to enforce input and output are on the same mode
         new_heralds = {
             "input": circuit.heralds["input"],
@@ -292,16 +295,13 @@ class Circuit:
             self.__circuit_spec = self.__circuit_spec + add_cs
         else:
             self.__circuit_spec.append(
-                [
-                    "group",
-                    (
-                        add_cs,
-                        name,
-                        mode,
-                        mode + circuit.n_modes - 1,
-                        new_heralds,
-                    ),
-                ]
+                Group(
+                    add_cs,
+                    name,
+                    mode,
+                    mode + circuit.n_modes - 1,
+                    new_heralds,
+                )
             )
         return
 
@@ -345,17 +345,11 @@ class Circuit:
                 "Beam splitter must act across two different modes."
             )
         self._mode_in_range(mode_2)
+        # Validate loss before updating circuit spec
         check_loss(loss)
-        # Check correct convention is given
-        all_convs = ["Rx", "H"]
-        if convention not in all_convs:
-            msg = "Provided beam splitter convention should in ['"
-            for conv in all_convs:
-                msg += conv + ", "
-            msg = msg[:-2] + "']"
-            raise ValueError(msg)
+        # Then update circuit spec
         self.__circuit_spec.append(
-            ["bs", (mode_1, mode_2, reflectivity, convention)]
+            BeamSplitter(mode_1, mode_2, reflectivity, convention)
         )
         if isinstance(loss, Parameter) or loss > 0:
             self.loss(mode_1, loss)
@@ -378,7 +372,7 @@ class Circuit:
         mode = self._map_mode(mode)
         self._mode_in_range(mode)
         check_loss(loss)
-        self.__circuit_spec.append(["ps", (mode, phi)])
+        self.__circuit_spec.append(PhaseShifter(mode, phi))
         if isinstance(loss, Parameter) or loss > 0:
             self.loss(mode, loss)
 
@@ -397,7 +391,7 @@ class Circuit:
         mode = self._map_mode(mode)
         self._mode_in_range(mode)
         check_loss(loss)
-        self.__circuit_spec.append(["loss", (mode, loss)])
+        self.__circuit_spec.append(Loss(mode, loss))
 
     def barrier(self, modes: list | None = None) -> None:
         """
@@ -415,7 +409,7 @@ class Circuit:
         modes = [self._map_mode(i) for i in modes]
         for m in modes:
             self._mode_in_range(m)
-        self.__circuit_spec.append(["barrier", (modes,)])
+        self.__circuit_spec.append(Barrier(modes))
 
     def mode_swaps(self, swaps: dict) -> None:
         """
@@ -431,21 +425,13 @@ class Circuit:
                 locations that they are to be swapped to.
 
         """
-        # Remap swap dict
+        # Remap swap dict and check modes
         swaps = {
             self._map_mode(mi): self._map_mode(mo) for mi, mo in swaps.items()
         }
-        # Perform some error checking steps
-        in_modes = sorted(swaps.keys())
-        out_modes = sorted(swaps.values())
-        if in_modes != out_modes:
-            raise ValueError(
-                "Mode swaps not complete, dictionary keys and values should "
-                "contain the same modes."
-            )
-        for m in in_modes:
+        for m in list(swaps.keys()) + list(swaps.values()):
             self._mode_in_range(m)
-        self.__circuit_spec.append(["mode_swaps", (swaps, None)])
+        self.__circuit_spec.append(ModeSwaps(swaps))
 
     def herald(
         self, n_photons: int, input_mode: int, output_mode: int | None = None
@@ -570,19 +556,17 @@ class Circuit:
                 Should either be 'svg' or 'mpl', defaults to 'svg'.
 
         """
-        self.__show_parameter_values = show_parameter_values
         return_ = Display(
             self,
             display_loss=display_loss,
             mode_labels=mode_labels,
             display_type=display_type,
+            show_parameter_values=show_parameter_values,
         )
         if display_type == "mpl":
             plt.show()
         elif display_type == "svg":
             display.display(return_)
-        # Return show parameter value attribute to default value after display
-        self.__show_parameter_values = False
         return
 
     def get_all_params(self) -> list:
@@ -590,8 +574,8 @@ class Circuit:
         Returns all the Parameter objects used as part of creating the circuit.
         """
         all_params = []
-        for _, params in unpack_circuit_spec(self.__circuit_spec):
-            for p in params:
+        for spec in unpack_circuit_spec(self.__circuit_spec):
+            for p in spec.values():
                 if isinstance(p, Parameter) and p not in all_params:
                     all_params.append(p)
         return all_params
@@ -675,23 +659,25 @@ class Circuit:
         """
         circuit = CompiledCircuit(self.n_modes)
 
-        for cs, params in unpack_circuit_spec(self.__circuit_spec):
-            got_params = [
-                p.get() if isinstance(p, Parameter) else p for p in params
-            ]
-            if cs == "bs":
-                circuit.add_bs(*got_params)
-            elif cs == "ps":
-                circuit.add_ps(*got_params)
-            elif cs == "loss":
-                circuit.add_loss(*got_params)
-            elif cs == "barrier":
+        for spec in unpack_circuit_spec(self.__circuit_spec):
+            if isinstance(spec, BeamSplitter):
+                circuit.add_bs(
+                    spec.mode_1,
+                    spec.mode_2,
+                    spec._reflectivity,
+                    spec.convention,
+                )
+            elif isinstance(spec, PhaseShifter):
+                circuit.add_ps(spec.mode, spec._phi)
+            elif isinstance(spec, Loss):
+                circuit.add_loss(spec.mode, spec._loss)
+            elif isinstance(spec, Barrier):
                 pass
-            elif cs == "mode_swaps":
-                circuit.add_mode_swaps(got_params[0])
-            elif cs == "unitary":
-                unitary = CompiledUnitary(params[1], params[2])
-                circuit.add(unitary, params[0])
+            elif isinstance(spec, ModeSwaps):
+                circuit.add_mode_swaps(spec.swaps)
+            elif isinstance(spec, UnitaryMatrix):
+                unitary = CompiledUnitary(spec.unitary, spec.label)
+                circuit.add(unitary, spec.mode)
             else:
                 raise CircuitCompilationError(
                     "Component in circuit spec not recognised."
@@ -758,56 +744,7 @@ class Circuit:
         ]
         return new_circuit_spec
 
-    def _get_display_spec(self) -> list:
-        """
-        Creates a parameterized version of the circuit build spec using the
-        included components.
-        """
-        display_spec = []
-        for cs, params in self.__circuit_spec:
-            # Convert parameters into labels if specified or values if not
-            if not self.__show_parameter_values:
-                cparams = [
-                    p.label
-                    if (isinstance(p, Parameter) and p.label is not None)
-                    else p.get()
-                    if isinstance(p, Parameter)
-                    else p
-                    for p in params
-                ]
-            else:
-                cparams = [
-                    p.get() if isinstance(p, Parameter) else p for p in params
-                ]
-            # Adjust build spec for each component
-            if cs == "bs":
-                display_spec.append(
-                    ("BS", [cparams[0], cparams[1]], (cparams[2]))
-                )
-            elif cs == "ps":
-                display_spec.append(("PS", cparams[0], (cparams[1])))
-            elif cs == "loss":
-                if display_loss_check(cparams[1]):
-                    display_spec.append(("LC", cparams[0], (cparams[1])))
-            elif cs == "barrier":
-                display_spec.append(("barrier", cparams[0], None))
-            elif cs == "mode_swaps":
-                display_spec.append(("mode_swaps", cparams[0], None))
-            elif cs == "unitary":
-                nm = params[1].shape[0]
-                display_spec.append(
-                    ("unitary", [cparams[0], cparams[0] + nm - 1], params[2])
-                )
-            elif cs == "group":
-                display_spec.append(
-                    ("group", [params[2], params[3]], (params[1], params[4]))
-                )
-            else:
-                raise DisplayError("Component in circuit spec not recognised.")
-
-        return display_spec
-
-    def _freeze_params(self, spec: list[list] | tuple) -> list | tuple:
+    def _freeze_params(self, circuit_spec: list[Component]) -> list[Component]:
         """
         Takes a provided circuit spec and will remove get any Parameter objects
         with their currently set values.
@@ -815,16 +752,16 @@ class Circuit:
         new_spec = []
         # Loop over spec and either call function again or add the value to the
         # new spec
-        for s in spec:
-            if isinstance(s, (list, tuple)):
-                new_spec.append(self._freeze_params(s))
-            elif isinstance(s, Parameter):
-                new_spec.append(s.get())
+        for spec in circuit_spec:
+            spec = copy(spec)  # noqa: PLW2901
+            if isinstance(spec, Group):
+                spec.circuit_spec = self._freeze_params(spec.circuit_spec)
+                new_spec.append(spec)
             else:
-                new_spec.append(s)
-        # If original spec was tuple than convert new spec to tuple
-        if isinstance(spec, tuple):
-            return tuple(new_spec)
+                for name, value in zip(spec.fields(), spec.values()):
+                    if isinstance(value, Parameter):
+                        setattr(spec, name, value.get())
+                new_spec.append(spec)
         return new_spec
 
     def _get_circuit_spec(self) -> list:

--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -699,9 +699,7 @@ class Circuit:
         if isinstance(mode, bool):
             raise TypeError("Mode number should be an integer.")
         if not isinstance(mode, int):
-            if int(mode) == mode:
-                mode = int(mode)
-            else:
+            if int(mode) != mode:
                 raise TypeError("Mode number should be an integer.")
         if not (0 <= mode < self.n_modes):
             raise ModeRangeError(

--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -74,7 +74,7 @@ class Circuit:
             else:
                 raise TypeError("Number of modes should be an integer.")
         self.__n_modes = n_modes
-        self.__circuit_spec: list[list] = []
+        self.__circuit_spec: list[Component] = []
         self.__in_heralds: dict[int, int] = {}
         self.__out_heralds: dict[int, int] = {}
         self.__external_in_heralds: dict[int, int] = {}
@@ -749,7 +749,7 @@ class Circuit:
         Takes a provided circuit spec and will remove get any Parameter objects
         with their currently set values.
         """
-        new_spec = []
+        new_spec: list[Component] = []
         # Loop over spec and either call function again or add the value to the
         # new spec
         for spec in circuit_spec:

--- a/lightworks/sdk/circuit/circuit_utils.py
+++ b/lightworks/sdk/circuit/circuit_utils.py
@@ -18,10 +18,20 @@
 Contains a number of different utility functions for modifying circuits.
 """
 
+from copy import copy
 from numbers import Number
 from typing import Any
 
 from ..utils import add_mode_to_unitary
+from .components import (
+    Barrier,
+    BeamSplitter,
+    Group,
+    Loss,
+    ModeSwaps,
+    PhaseShifter,
+    UnitaryMatrix,
+)
 from .parameters import Parameter
 
 
@@ -39,16 +49,14 @@ def unpack_circuit_spec(circuit_spec: list) -> list:
 
     """
     new_spec = list(circuit_spec)
-    components = [i[0] for i in circuit_spec]
-    while "group" in components:
+    while any(isinstance(s, Group) for s in new_spec):
         temp_spec = []
         for spec in circuit_spec:
-            if spec[0] != "group":
+            if not isinstance(spec, Group):
                 temp_spec += [spec]
             else:
-                temp_spec += spec[1][0]
+                temp_spec += spec.circuit_spec
         new_spec = temp_spec
-        components = [i[0] for i in new_spec]
 
     return new_spec
 
@@ -70,23 +78,24 @@ def add_modes_to_circuit_spec(circuit_spec: list, mode: int) -> list:
 
     """
     new_circuit_spec = []
-    for c, params in circuit_spec:
-        params = list(params)
-        if c in ["bs"]:
-            params[0] += mode
-            params[1] += mode
-        elif c == "barrier":
-            params = [p + mode for p in params[0]]
-            params = (params,)
-        elif c == "mode_swaps":
-            params[0] = {k + mode: v + mode for k, v in params[0].items()}
-        elif c == "group":
-            params[0] = add_modes_to_circuit_spec(params[0], mode)
-            params[2] += mode
-            params[3] += mode
+    for spec in circuit_spec:
+        spec = copy(spec)
+        if isinstance(spec, BeamSplitter):
+            spec.mode_1 += mode
+            spec.mode_2 += mode
+        elif isinstance(spec, Barrier):
+            spec.modes = [p + mode for p in spec.modes]
+        elif isinstance(spec, ModeSwaps):
+            spec.swaps = {k + mode: v + mode for k, v in spec.swaps.items()}
+        elif isinstance(spec, Group):
+            spec.circuit_spec = add_modes_to_circuit_spec(
+                spec.circuit_spec, mode
+            )
+            spec.mode_1 += mode
+            spec.mode_2 += mode
         else:
-            params[0] += mode
-        new_circuit_spec.append([c, tuple(params)])
+            spec.mode += mode
+        new_circuit_spec.append(spec)
     return new_circuit_spec
 
 
@@ -106,53 +115,57 @@ def add_empty_mode_to_circuit_spec(circuit_spec: list, mode: int) -> list:
 
     """
     new_circuit_spec = []
-    for c, params in circuit_spec:
-        params = list(params)
-        if c in ["bs"]:
-            params[0] += 1 if params[0] >= mode else 0
-            params[1] += 1 if params[1] >= mode else 0
-        elif c == "barrier":
-            params = [p + 1 if p >= mode else p for p in params[0]]
-            params = (params,)
-        elif c == "mode_swaps":
+    for spec in circuit_spec:
+        spec = copy(spec)
+        if isinstance(spec, BeamSplitter):
+            spec.mode_1 += 1 if spec.mode_1 >= mode else 0
+            spec.mode_2 += 1 if spec.mode_2 >= mode else 0
+        elif isinstance(spec, Barrier):
+            spec.modes = [p + 1 if p >= mode else p for p in spec.modes]
+        elif isinstance(spec, ModeSwaps):
             swaps = {}
-            for k, v in params[0].items():
+            for k, v in spec.swaps.items():
                 k += 1 if k >= mode else 0
                 v += 1 if v >= mode else 0
                 swaps[k] = v
-            params[0] = swaps
-        elif c == "group":
-            params[0] = add_empty_mode_to_circuit_spec(params[0], mode)
+            spec.swaps = swaps
+        elif isinstance(spec, Group):
+            spec.circuit_spec = add_empty_mode_to_circuit_spec(
+                spec.circuit_spec, mode
+            )
             # Shift unitary mode range
-            params[2] += 1 if params[2] >= mode else 0
-            params[3] += 1 if params[3] >= mode else 0
+            spec.mode_1 += 1 if spec.mode_1 >= mode else 0
+            spec.mode_2 += 1 if spec.mode_2 >= mode else 0
             # Update herald values
-            in_heralds, out_heralds = params[4]["input"], params[4]["output"]
+            in_heralds, out_heralds = (
+                spec.heralds["input"],
+                spec.heralds["output"],
+            )
             new_in_heralds = {}
             for m, n in in_heralds.items():
-                if m >= (mode - params[2]) and mode - params[2] >= 0:
+                if m >= (mode - spec.mode_1) and mode - spec.mode_1 >= 0:
                     m += 1
                 new_in_heralds[m] = n
             new_out_heralds = {}
             for m, n in out_heralds.items():
-                if m >= (mode - params[2]) and mode - params[2] >= 0:
+                if m >= (mode - spec.mode_1) and mode - spec.mode_1 >= 0:
                     m += 1
                 new_out_heralds[m] = n
-            params[4] = {"input": new_in_heralds, "output": new_out_heralds}
-        elif c == "unitary":
-            params[0] += 1 if params[0] >= mode else 0
+            spec.heralds = {"input": new_in_heralds, "output": new_out_heralds}
+        elif isinstance(spec, UnitaryMatrix):
+            spec.mode += 1 if spec.mode >= mode else 0
             # Expand unitary if required
-            if params[0] < mode < params[0] + params[1].shape[0]:
-                add_mode = mode - params[0]
+            if spec.mode < mode < spec.mode + spec.unitary.shape[0]:
+                add_mode = mode - spec.mode
                 # Update unitary value
-                params[1] = add_mode_to_unitary(params[1], add_mode)
+                spec.unitary = add_mode_to_unitary(spec.unitary, add_mode)
         else:
-            params[0] += 1 if params[0] >= mode else 0
-        new_circuit_spec.append([c, tuple(params)])
+            spec.mode += 1 if spec.mode >= mode else 0
+        new_circuit_spec.append(spec)
     return new_circuit_spec
 
 
-def convert_non_adj_beamsplitters(spec: list) -> list:
+def convert_non_adj_beamsplitters(circuit_spec: list) -> list:
     """
     Takes a given circuit spec and removes all beam splitters acting on
     non-adjacent modes by replacing with a mode swap and adjacent beam
@@ -160,8 +173,8 @@ def convert_non_adj_beamsplitters(spec: list) -> list:
 
     Args:
 
-        spec (list) : The circuit spec to remove beam splitter on non-adjacent
-            modes from.
+        circuit_spec (list) : The circuit spec to remove beam splitter on
+            non-adjacent modes from.
 
     Returns:
 
@@ -169,9 +182,13 @@ def convert_non_adj_beamsplitters(spec: list) -> list:
 
     """
     new_spec: list[list] = []
-    for s in spec:
-        if s[0] == "bs" and abs(s[1][0] - s[1][1]) != 1:
-            m1, m2 = s[1][0:2]
+    for spec in circuit_spec:
+        spec = copy(spec)
+        if (
+            isinstance(spec, BeamSplitter)
+            and abs(spec.mode_2 - spec.mode_1) != 1
+        ):
+            m1, m2 = spec.mode_1, spec.mode_2
             if m1 > m2:
                 m1, m2 = m2, m1
             mid = int((m1 + m2 - 1) / 2)
@@ -180,26 +197,26 @@ def convert_non_adj_beamsplitters(spec: list) -> list:
                 swaps[i] = mid if i == m1 else i - 1
             for i in range(mid + 1, m2 + 1):
                 swaps[i] = mid + 1 if i == m2 else i + 1
-            new_spec.append(["mode_swaps", (swaps, None)])
+            new_spec.append(ModeSwaps(swaps))
             # If original modes were inverted then invert here too
             add1, add2 = mid, mid + 1
-            if s[1][0] > s[1][1]:
+            if spec.mode_1 > spec.mode_2:
                 add1, add2 = add2, add1
             # Add beam splitter on new modes
-            new_spec.append(["bs", (add1, add2, s[1][2], s[1][3])])
+            new_spec.append(
+                BeamSplitter(add1, add2, spec.reflectivity, spec.convention)
+            )
             swaps = {v: k for k, v in swaps.items()}
-            new_spec.append(["mode_swaps", (swaps, None)])
-        elif s[0] == "group":
-            new_s1 = list(s[1])
-            new_s1[0] = convert_non_adj_beamsplitters(s[1][0])
-            s = [s[0], tuple(new_s1)]
-            new_spec.append(s)
+            new_spec.append(ModeSwaps(swaps))
+        elif isinstance(spec, Group):
+            spec.circuit_spec = convert_non_adj_beamsplitters(spec.circuit_spec)
+            new_spec.append(spec)
         else:
-            new_spec.append(s)
+            new_spec.append(spec)
     return new_spec
 
 
-def compress_mode_swaps(spec: list) -> list:
+def compress_mode_swaps(circuit_spec: list) -> list:
     """
     Takes a provided circuit spec and will try to compress any more swaps
     such that the circuit length is reduced. Note that any components in a
@@ -207,7 +224,7 @@ def compress_mode_swaps(spec: list) -> list:
 
     Args:
 
-        spec (list) : The circuit spec which is to be processed.
+        circuit_spec (list) : The circuit spec which is to be processed.
 
     Returns:
 
@@ -217,29 +234,34 @@ def compress_mode_swaps(spec: list) -> list:
     new_spec = []
     to_skip = []
     # Loop over each item in original spec
-    for i, s in enumerate(spec):
+    for i, spec in enumerate(circuit_spec):
+        spec = copy(spec)
         if i in to_skip:
             continue
         # If it a mode swap then check for subsequent mode swaps
-        if s[0] == "mode_swaps":
+        if isinstance(spec, ModeSwaps):
             blocked_modes = set()
-            for j, s2 in enumerate(spec[i + 1 :]):
+            for j, spec2 in enumerate(circuit_spec[i + 1 :]):
                 # Block modes with components other than the mode swap on
-                if s2[0] == "ps":
+                if isinstance(spec2, (PhaseShifter, Loss)):
                     # NOTE: In principle a phase shift doesn't need to
                     # block a mode and instead we could modify it's
                     # location
-                    blocked_modes.add(s2[1][0])
-                elif s2[0] == "bs":
-                    blocked_modes.add(s2[1][0])
-                    blocked_modes.add(s2[1][1])
-                elif s2[0] == "group":
-                    for m in range(s2[1][2], s2[1][3] + 1):
+                    blocked_modes.add(spec2.mode)
+                elif isinstance(spec2, BeamSplitter):
+                    blocked_modes.add(spec2.mode_1)
+                    blocked_modes.add(spec2.mode_2)
+                elif isinstance(spec2, Group):
+                    for m in range(spec2.mode_1, spec2.mode_2 + 1):
                         blocked_modes.add(m)
-                elif s2[0] == "mode_swaps":
+                # TODO: Test this works
+                elif isinstance(spec2, UnitaryMatrix):
+                    for m in range(spec2.mode, spec2.array.shape[0]):
+                        blocked_modes.add(m)
+                elif isinstance(spec2, ModeSwaps):
                     # When a mode swap is found check if any of its mode
                     # are in the blocked mode
-                    swaps = s2[1][0]
+                    swaps = spec2.swaps
                     for m in swaps:
                         # If they are then block all other modes of swap
                         if m in blocked_modes:
@@ -249,13 +271,13 @@ def compress_mode_swaps(spec: list) -> list:
                     else:
                         # Otherwise combine the original and found swap
                         # and update spec entry
-                        new_swaps = combine_mode_swap_dicts(s[1][0], swaps)
-                        s = ["mode_swaps", (new_swaps, None)]
+                        new_swaps = combine_mode_swap_dicts(spec.swaps, swaps)
+                        spec.swaps = new_swaps
                         # Also set to skip the swap that was combine
                         to_skip.append(i + 1 + j)
-            new_spec.append(s)
+            new_spec.append(spec)
         else:
-            new_spec.append(s)
+            new_spec.append(spec)
 
     return new_spec
 

--- a/lightworks/sdk/circuit/circuit_utils.py
+++ b/lightworks/sdk/circuit/circuit_utils.py
@@ -255,9 +255,10 @@ def compress_mode_swaps(circuit_spec: list) -> list:
                 elif isinstance(spec2, Group):
                     for m in range(spec2.mode_1, spec2.mode_2 + 1):
                         blocked_modes.add(m)
-                # TODO: Test this works
                 elif isinstance(spec2, UnitaryMatrix):
-                    for m in range(spec2.mode, spec2.unitary.shape[0]):
+                    for m in range(
+                        spec2.mode, spec2.mode + spec2.unitary.shape[0]
+                    ):
                         blocked_modes.add(m)
                 elif isinstance(spec2, ModeSwaps):
                     # When a mode swap is found check if any of its mode

--- a/lightworks/sdk/circuit/circuit_utils.py
+++ b/lightworks/sdk/circuit/circuit_utils.py
@@ -26,6 +26,7 @@ from ..utils import add_mode_to_unitary
 from .components import (
     Barrier,
     BeamSplitter,
+    Component,
     Group,
     Loss,
     ModeSwaps,
@@ -181,7 +182,7 @@ def convert_non_adj_beamsplitters(circuit_spec: list) -> list:
         list : The processed circuit spec.
 
     """
-    new_spec: list[list] = []
+    new_spec: list[Component] = []
     for spec in circuit_spec:
         spec = copy(spec)
         if (
@@ -256,7 +257,7 @@ def compress_mode_swaps(circuit_spec: list) -> list:
                         blocked_modes.add(m)
                 # TODO: Test this works
                 elif isinstance(spec2, UnitaryMatrix):
-                    for m in range(spec2.mode, spec2.array.shape[0]):
+                    for m in range(spec2.mode, spec2.unitary.shape[0]):
                         blocked_modes.add(m)
                 elif isinstance(spec2, ModeSwaps):
                     # When a mode swap is found check if any of its mode

--- a/lightworks/sdk/circuit/components.py
+++ b/lightworks/sdk/circuit/components.py
@@ -23,6 +23,7 @@ from .parameters import Parameter
 # ruff: noqa: ANN202, ANN204, D101
 
 
+@dataclass(slots=True)
 class Component:
     def fields(self) -> list:
         """Returns a list of all field from the component dataclass."""
@@ -40,7 +41,7 @@ class BeamSplitter(Component):
     reflectivity: float | Parameter
     convention: str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Validate reflectivity
         if not isinstance(self.reflectivity, Parameter):
             if not 0 <= self.reflectivity <= 1:
@@ -94,7 +95,7 @@ class Barrier(Component):
 class ModeSwaps(Component):
     swaps: dict
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Check swaps are valid
         in_modes = sorted(self.swaps.keys())
         out_modes = sorted(self.swaps.values())
@@ -120,7 +121,7 @@ class UnitaryMatrix(Component):
     unitary: np.ndarray
     label: str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Check type of supplied unitary
         if not isinstance(self.unitary, (np.ndarray, list)):
             raise TypeError("Unitary should be a numpy array or list.")

--- a/lightworks/sdk/circuit/components.py
+++ b/lightworks/sdk/circuit/components.py
@@ -1,0 +1,135 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from dataclasses import dataclass, fields
+
+import numpy as np
+
+from ..utils import check_unitary
+from .parameters import Parameter
+
+# ruff: noqa: ANN202, ANN204, D101
+
+
+class Component:
+    def fields(self) -> list:
+        """Returns a list of all field from the component dataclass."""
+        return [f.name for f in fields(self)]
+
+    def values(self) -> list:
+        """Returns a list of all values from the component dataclass."""
+        return [getattr(self, f.name) for f in fields(self)]
+
+
+@dataclass(slots=True)
+class BeamSplitter(Component):
+    mode_1: int
+    mode_2: int
+    reflectivity: float | Parameter
+    convention: str
+
+    def __post_init__(self):
+        # Validate reflectivity
+        if not isinstance(self.reflectivity, Parameter):
+            if not 0 <= self.reflectivity <= 1:
+                raise ValueError("Reflectivity must be in range [0,1].")
+        # And check beam splitter convention
+        all_convs = ["Rx", "H"]
+        if self.convention not in all_convs:
+            msg = "Provided beam splitter convention should in ['"
+            for conv in all_convs:
+                msg += conv + ", "
+            msg = msg[:-2] + "']"
+            raise ValueError(msg)
+
+    @property
+    def _reflectivity(self) -> float:
+        if isinstance(self.reflectivity, Parameter):
+            return self.reflectivity.get()
+        return self.reflectivity
+
+
+@dataclass(slots=True)
+class PhaseShifter(Component):
+    mode: int
+    phi: float | Parameter
+
+    @property
+    def _phi(self) -> float:
+        if isinstance(self.phi, Parameter):
+            return self.phi.get()
+        return self.phi
+
+
+@dataclass(slots=True)
+class Loss(Component):
+    mode: int
+    loss: float | Parameter
+
+    @property
+    def _loss(self) -> float:
+        if isinstance(self.loss, Parameter):
+            return self.loss.get()
+        return self.loss
+
+
+@dataclass(slots=True)
+class Barrier(Component):
+    modes: list
+
+
+@dataclass(slots=True)
+class ModeSwaps(Component):
+    swaps: dict
+
+    def __post_init__(self):
+        # Check swaps are valid
+        in_modes = sorted(self.swaps.keys())
+        out_modes = sorted(self.swaps.values())
+        if in_modes != out_modes:
+            raise ValueError(
+                "Mode swaps not complete, dictionary keys and values should "
+                "contain the same modes."
+            )
+
+
+@dataclass(slots=True)
+class Group(Component):
+    circuit_spec: list
+    name: str
+    mode_1: int
+    mode_2: int
+    heralds: dict
+
+
+@dataclass(slots=True)
+class UnitaryMatrix(Component):
+    mode: int
+    unitary: np.ndarray
+    label: str
+
+    def __post_init__(self):
+        # Check type of supplied unitary
+        if not isinstance(self.unitary, (np.ndarray, list)):
+            raise TypeError("Unitary should be a numpy array or list.")
+        self.unitary = np.array(self.unitary)
+
+        # Ensure unitary is valid
+        if not check_unitary(self.unitary):
+            raise ValueError("Provided matrix is not unitary.")
+
+        # Also check label is a string
+        if not isinstance(self.label, str):
+            raise TypeError("Label for unitary should be a string.")

--- a/lightworks/sdk/circuit/unitary.py
+++ b/lightworks/sdk/circuit/unitary.py
@@ -36,6 +36,6 @@ class Unitary(Circuit):
 
     def __init__(self, unitary: np.ndarray, label: str = "U") -> None:
         super().__init__(int(unitary.shape[0]))
-        self._Circuit__circuit_spec.append(UnitaryMatrix(0, unitary, label))
+        self._Circuit__circuit_spec = [UnitaryMatrix(0, unitary, label)]
 
         return

--- a/lightworks/sdk/circuit/unitary.py
+++ b/lightworks/sdk/circuit/unitary.py
@@ -18,8 +18,8 @@ Dedicated unitary component for implementing unitary matrices on a circuit.
 
 import numpy as np
 
-from ..utils import check_unitary
 from .circuit import Circuit
+from .components import UnitaryMatrix
 
 
 class Unitary(Circuit):
@@ -35,20 +35,7 @@ class Unitary(Circuit):
     """
 
     def __init__(self, unitary: np.ndarray, label: str = "U") -> None:
-        # Check type of supplied unitary
-        if not isinstance(unitary, (np.ndarray, list)):
-            raise TypeError("Unitary should be a numpy array or list.")
-        unitary = np.array(unitary)
-
-        # Ensure unitary is valid
-        if not check_unitary(unitary):
-            raise ValueError("Provided matrix is not unitary.")
-
-        # Also check label is a string
-        if not isinstance(label, str):
-            raise TypeError("Label for unitary should be a string.")
-
         super().__init__(int(unitary.shape[0]))
-        self._Circuit__circuit_spec = [["unitary", (0, unitary, label)]]
+        self._Circuit__circuit_spec.append(UnitaryMatrix(0, unitary, label))
 
         return

--- a/lightworks/sdk/visualisation/display.py
+++ b/lightworks/sdk/visualisation/display.py
@@ -32,6 +32,7 @@ def Display(  # noqa: N802
     display_loss: bool = False,
     mode_labels: list[str] | None = None,
     display_type: str = "svg",
+    show_parameter_values: bool = False,
 ) -> tuple[matplotlib.figure.Figure, plt.Axes] | drawsvg.Drawing:
     """
     Used to Display a circuit from lightworks in the chosen format.
@@ -51,6 +52,9 @@ def Display(  # noqa: N802
             matplotlib module should be used for displaying the circuit. Should
             either be 'svg' or 'mpl', defaults to 'svg'.
 
+        show_parameter_values (bool, optional) : Shows the values of parameters
+            instead of the associated labels if specified.
+
     Returns:
 
         (fig, ax) | Drawing : The created figure and axis or drawing for the
@@ -63,10 +67,14 @@ def Display(  # noqa: N802
 
     """
     if display_type == "mpl":
-        disp = DrawCircuitMPL(circuit, display_loss, mode_labels)
+        disp = DrawCircuitMPL(
+            circuit, display_loss, mode_labels, show_parameter_values
+        )
         fig, ax = disp.draw()
         return (fig, ax)
     if display_type == "svg":
-        disp_svg = DrawCircuitSVG(circuit, display_loss, mode_labels)
+        disp_svg = DrawCircuitSVG(
+            circuit, display_loss, mode_labels, show_parameter_values
+        )
         return disp_svg.draw()
     raise DisplayError("Display type not recognised.")

--- a/lightworks/sdk/visualisation/display_utils.py
+++ b/lightworks/sdk/visualisation/display_utils.py
@@ -1,0 +1,29 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from ..circuit.parameters import Parameter
+
+
+def process_parameter_value(value: Any, show_parameter_value: bool) -> Any:
+    """
+    Takes a provided value and will convert into a label or value if it is
+    provided as a parameter.
+    """
+    if not isinstance(value, Parameter):
+        return value
+    if show_parameter_value:
+        return value.get()
+    return value.label if value.label is not None else value.get()

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -17,8 +17,18 @@ from typing import TYPE_CHECKING
 import drawsvg as draw
 import numpy as np
 
+from ..circuit.components import (
+    Barrier,
+    BeamSplitter,
+    Group,
+    Loss,
+    ModeSwaps,
+    PhaseShifter,
+    UnitaryMatrix,
+)
 from ..utils import DisplayError
 from .display_components_svg import DrawSVGComponents
+from .display_utils import process_parameter_value
 
 if TYPE_CHECKING:
     from ..circuit import Circuit
@@ -42,6 +52,9 @@ class DrawCircuitSVG:
             labels which will be used to name the mode something other than
             numerical values. Can be set to None to use default values.
 
+        show_parameter_values (bool, optional) : Shows the values of parameters
+            instead of the associated labels if specified.
+
     """
 
     def __init__(
@@ -49,10 +62,12 @@ class DrawCircuitSVG:
         circuit: "Circuit",
         display_loss: bool = False,
         mode_labels: list[str] | None = None,
+        show_parameter_values: bool = False,
     ) -> None:
         self.circuit = circuit
         self.display_loss = display_loss
         self.herald_modes = self.circuit._internal_modes
+        self.show_parameter_values = show_parameter_values
         # Set a waveguide width and get mode number
         self.wg_width = 8
         self.n_modes = self.circuit.n_modes
@@ -121,37 +136,37 @@ class DrawCircuitSVG:
                 if m not in self.herald_modes:
                     self._add_wg(self.x_locations[m], self.y_locations[m], 50)
                     self.x_locations[m] += 50
-        # Loop over each element in the build spec and add
-        for spec in self.circuit._display_spec:
-            c, modes = spec[0:2]
-            params = spec[2]
-            if c == "PS":
-                self._add_ps(modes, params)
-            elif c == "BS":  # TODO
-                m1, m2 = modes
-                ref = params
-                if m1 > m2:
-                    m1, m2 = m2, m1
-                self._add_bs(m1, m2, ref)
-            elif c == "LC" and self.display_loss:
-                self._add_loss(modes, params)
-            elif c == "barrier":
-                self._add_barrier(modes)
-            elif c == "mode_swaps":  # TODO
-                if not modes:
+        # Loop over each element in the circuit spec and add
+        for spec in self.circuit._get_circuit_spec():
+            if isinstance(spec, PhaseShifter):
+                phi = process_parameter_value(
+                    spec.phi, self.show_parameter_values
+                )
+                self._add_ps(spec.mode, phi)
+            elif isinstance(spec, BeamSplitter):
+                reflectivity = process_parameter_value(
+                    spec.reflectivity, self.show_parameter_values
+                )
+                self._add_bs(spec.mode_1, spec.mode_2, reflectivity)
+            elif isinstance(spec, Loss):
+                loss = process_parameter_value(
+                    spec.loss, self.show_parameter_values
+                )
+                self._add_loss(spec.mode, loss)
+            elif isinstance(spec, Barrier):
+                self._add_barrier(spec.modes)
+            elif isinstance(spec, ModeSwaps):
+                if not spec.swaps:
                     continue
-                self._add_mode_swaps(modes)
-            elif c == "unitary":  # TODO
-                m1, m2 = modes
-                if m1 > m2:
-                    m1, m2 = m2, m1
-                self._add_unitary(m1, m2, params)
-            elif c == "group":  # TODO
-                m1, m2 = modes
-                if m1 > m2:
-                    m1, m2 = m2, m1
-                name, heralds = params
-                self._add_grouped_circuit(m1, m2, name, heralds)
+                self._add_mode_swaps(spec.swaps)
+            elif isinstance(spec, UnitaryMatrix):
+                self._add_unitary(
+                    spec.mode, spec.mode + spec.unitary.shape[0] - 1, spec.label
+                )
+            elif isinstance(spec, Group):
+                self._add_grouped_circuit(
+                    spec.mode_1, spec.mode_2, spec.name, spec.heralds
+                )
 
         maxloc = max(self.x_locations)
         # Extend final waveguide if herald included
@@ -307,6 +322,8 @@ class DrawCircuitSVG:
 
     def _add_bs(self, mode1: int, mode2: int, ref: float) -> None:
         """Add a beam splitter across to provided modes to the drawing."""
+        if mode1 > mode2:
+            mode1, mode2 = mode2, mode1
         size_x = 50  # x beam splitter size
         con_length = 50  # input/output waveguide length
         offset = 50  # Offset of beam splitter shape from mode centres
@@ -523,6 +540,8 @@ class DrawCircuitSVG:
         self, mode1: int, mode2: int, name: str, heralds: dict
     ) -> None:
         """Add a grouped_circuit representation to the drawing."""
+        if mode1 > mode2:
+            mode1, mode2 = mode2, mode1
         size_x = 100  # Drawing x size
         con_length = 50  # Input/output waveguide lengths
         extra_length = 50 if heralds["input"] or heralds["output"] else 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ testpaths = [
 
 ## pytest coverage config
 [tool.coverage.run]
-omit = ["tests/*", "docs/*", "lightworks/sdk/optimisation/*"]
+omit = [
+    "tests/*",
+    "docs/*",
+    "lightworks/sdk/optimisation/*",
+    "lightworks/qubit/__init__.py"
+]
 
 ## mypy config
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ omit = [
     "tests/*",
     "docs/*",
     "lightworks/sdk/optimisation/*",
-    "lightworks/qubit/__init__.py"
+    "lightworks/qubit/converter/__init__.py"
 ]
 
 ## mypy config

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -25,6 +25,13 @@ from lightworks import (
     Unitary,
     random_unitary,
 )
+from lightworks.qubit import CNOT
+from lightworks.sdk.circuit.components import (
+    BeamSplitter,
+    Component,
+    Group,
+    ModeSwaps,
+)
 
 
 class TestCircuit:
@@ -276,7 +283,7 @@ class TestCircuit:
         circuit.unpack_groups()
         group_found = False
         for spec in circuit._get_circuit_spec():
-            if spec[0] == "group":
+            if isinstance(spec, Group):
                 group_found = True
         assert not group_found
 
@@ -296,9 +303,40 @@ class TestCircuit:
         # Apply method and check all remaining beam splitters
         circuit.remove_non_adjacent_bs()
         for spec in circuit._get_circuit_spec():
-            if spec[0] == "bs":
+            if isinstance(spec, BeamSplitter):
                 # Check it acts on adjacent modes, otherwise fail
-                if spec[1][0] != spec[1][1] - 1:
+                if spec.mode_1 != spec.mode_2 - 1:
+                    pytest.fail(
+                        "Beam splitter which acts on non-adjacent modes found "
+                        "in circuit spec."
+                    )
+
+    def test_remove_non_adj_bs_grouped_success(self):
+        """
+        Checks that the remove_non_adjacent_bs method of the circuit is able
+        to successfully remove all beam splitters which act on non-adjacent
+        modes when groups are included.
+        """
+        # Create circuit with beam splitters across non-adjacent modes
+        circuit = Circuit(8)
+        circuit.bs(0, 7)
+        circuit.bs(1, 4)
+        circuit.bs(2, 6)
+        circuit.bs(3, 7)
+        circuit.bs(0, 1)
+        # Then create smaller second circuit and add, with group = True
+        circuit2 = Circuit(6)
+        circuit2.bs(1, 4)
+        circuit2.bs(2, 5)
+        circuit2.bs(3)
+        circuit.add(circuit2, 1, group=True)
+        # Apply method and check all remaining beam splitters
+        circuit.remove_non_adjacent_bs()
+        circuit.unpack_groups()
+        for spec in circuit._get_circuit_spec():
+            if isinstance(spec, BeamSplitter):
+                # Check it acts on adjacent modes, otherwise fail
+                if spec.mode_1 != spec.mode_2 - 1:
                     pytest.fail(
                         "Beam splitter which acts on non-adjacent modes found "
                         "in circuit spec."
@@ -367,6 +405,27 @@ class TestCircuit:
         u2 = abs(circuit.U).round(8)
         assert (u1 == u2).all()
 
+    def test_compress_mode_swap_equivalance_unitary(self):
+        """
+        Tests the circuit compress_mode_swaps method retains the circuit
+        unitary while a unitary matrix component is included.
+        """
+        # Create circuit with a few components and then mode swaps
+        circuit = Circuit(8)
+        circuit.bs(0)
+        circuit.bs(4)
+        circuit.add(Unitary(random_unitary(4)), 2)
+        circuit.mode_swaps({1: 3, 3: 5, 5: 6, 6: 1})
+        circuit.mode_swaps({0: 1, 2: 4, 1: 2, 4: 0})
+        circuit.mode_swaps({5: 3, 3: 5})
+        circuit.bs(0)
+        circuit.bs(4)
+        # Apply method and check unitary equivalence
+        u1 = abs(circuit.U).round(8)
+        circuit.compress_mode_swaps()
+        u2 = abs(circuit.U).round(8)
+        assert (u1 == u2).all()
+
     def test_compress_mode_swap_removes_components(self):
         """
         Tests the circuit compress_mode_swaps method is able to reduce it down
@@ -386,7 +445,7 @@ class TestCircuit:
         circuit.compress_mode_swaps()
         counter = 0
         for spec in circuit._get_circuit_spec():
-            if spec[0] == "mode_swaps":
+            if isinstance(spec, ModeSwaps):
                 counter += 1
         assert counter == 2
 
@@ -408,7 +467,7 @@ class TestCircuit:
         circuit.unpack_groups()  # unpack groups for counting
         counter = 0
         for spec in circuit._get_circuit_spec():
-            if spec[0] == "mode_swaps":
+            if isinstance(spec, ModeSwaps):
                 counter += 1
         assert counter == 2
 
@@ -523,10 +582,12 @@ class TestCircuit:
         sub_circ.herald(1, 3, 3)
         circuit.add(sub_circ, 1)
         # Confirm beam splitters now act on modes 0 & 2 and 3 & 5
-        spec = circuit._Circuit__circuit_spec
+        spec = circuit._get_circuit_spec()
         # Get relevant elements from spec
-        assert spec[0][1][0:2] == (0, 2)
-        assert spec[1][1][0:2] == (3, 5)
+        assert spec[0].mode_1 == 0
+        assert spec[0].mode_2 == 2
+        assert spec[1].mode_1 == 3
+        assert spec[1].mode_2 == 5
 
     def test_heralded_circuit_addition_circ_modification_2(self):
         """
@@ -543,10 +604,12 @@ class TestCircuit:
         sub_circ.herald(1, 3, 3)
         circuit.add(sub_circ, 0)
         # Confirm beam splitters now act on modes 0 & 2 and 3 & 5
-        spec = circuit._Circuit__circuit_spec
+        spec = circuit._get_circuit_spec()
         # Get relevant elements from spec
-        assert spec[0][1][0:2] == (1, 2)
-        assert spec[1][1][0:2] == (4, 5)
+        assert spec[0].mode_1 == 1
+        assert spec[0].mode_2 == 2
+        assert spec[1].mode_1 == 4
+        assert spec[1].mode_2 == 5
 
     def test_heralded_circuit_addition_circ_modification_3(self):
         """
@@ -563,10 +626,12 @@ class TestCircuit:
         sub_circ.herald(1, 1, 0)
         circuit.add(sub_circ, 1)
         # Confirm beam splitters now act on modes 0 & 2 and 3 & 5
-        spec = circuit._Circuit__circuit_spec
+        spec = circuit._get_circuit_spec()
         # Get relevant elements from spec
-        assert spec[0][1][0:2] == (0, 3)
-        assert spec[1][1][0:2] == (4, 5)
+        assert spec[0].mode_1 == 0
+        assert spec[0].mode_2 == 3
+        assert spec[1].mode_1 == 4
+        assert spec[1].mode_2 == 5
 
     def test_heralded_circuit_addition_circ_modification_all_herald(self):
         """
@@ -585,10 +650,12 @@ class TestCircuit:
         sub_circ.herald(1, 3, 3)
         circuit.add(sub_circ, 1)
         # Confirm beam splitters now act on modes 0 & 2 and 3 & 5
-        spec = circuit._Circuit__circuit_spec
+        spec = circuit._get_circuit_spec()
         # Get relevant elements from spec
-        assert spec[0][1][0:2] == (0, 5)
-        assert spec[1][1][0:2] == (6, 7)
+        assert spec[0].mode_1 == 0
+        assert spec[0].mode_2 == 5
+        assert spec[1].mode_1 == 6
+        assert spec[1].mode_2 == 7
 
     def test_heralded_two_circuit_addition_circ_modification(self):
         """
@@ -606,10 +673,12 @@ class TestCircuit:
         circuit.add(sub_circ, 2)
         circuit.add(sub_circ, 1)
         # Confirm beam splitters now act on modes 0 & 2 and 3 & 5
-        spec = circuit._Circuit__circuit_spec
+        spec = circuit._get_circuit_spec()
         # Get relevant elements from spec
-        assert spec[0][1][0:2] == (0, 2)
-        assert spec[1][1][0:2] == (5, 7)
+        assert spec[0].mode_1 == 0
+        assert spec[0].mode_2 == 2
+        assert spec[1].mode_1 == 5
+        assert spec[1].mode_2 == 7
 
     def test_input_modes(self):
         """
@@ -674,8 +743,8 @@ class TestCircuit:
         # Add bs on modes
         circuit.bs(*initial_modes)
         # Then check modes are converted to correct values
-        assert circuit._Circuit__circuit_spec[0][1][0] == final_modes[0]
-        assert circuit._Circuit__circuit_spec[0][1][1] == final_modes[1]
+        assert circuit._Circuit__circuit_spec[0].mode_1 == final_modes[0]
+        assert circuit._Circuit__circuit_spec[0].mode_2 == final_modes[1]
 
     def test_bs_invalid_convention(self):
         """
@@ -734,6 +803,36 @@ class TestCircuit:
         circuit._Circuit__circuit_spec = [["test", None]]
         with pytest.raises(CircuitCompilationError):
             circuit._build()
+
+    def test_all_circuit_spec_components(self):
+        """
+        Confirms that all elements in a created circuit spec are components
+        """
+        circuit = Circuit(6)
+        circuit.bs(0, 1)
+        circuit.ps(2, 2)
+        circuit.mode_swaps({0: 1, 1: 2, 2: 0})
+        circuit.barrier()
+        circuit.loss(3, 1)
+        # Define sub-circuit to add
+        sub_circuit = Circuit(4)
+        circuit.bs(0, 1)
+        circuit.ps(2, 2)
+        circuit.mode_swaps({0: 1, 1: 2, 2: 0})
+        circuit.barrier()
+        circuit.loss(3, 1)
+        # Also include CNOT
+        circuit.add(sub_circuit, 1, group=True)
+        circuit.add(CNOT(), 1)
+        # Check all are components
+        assert all(
+            isinstance(c, Component) for c in circuit._get_circuit_spec()
+        )
+        # Unpack the circuit spec and repeat
+        circuit.unpack_groups()
+        assert all(
+            isinstance(c, Component) for c in circuit._get_circuit_spec()
+        )
 
 
 class TestUnitary:

--- a/tests/sdk/compiledcircuit_test.py
+++ b/tests/sdk/compiledcircuit_test.py
@@ -172,3 +172,12 @@ class TestCompiledCircuit:
         circuit = CompiledCircuit(4)
         with pytest.raises(AttributeError):
             circuit.n_modes = 6
+
+    def test_bs_invalid_convention(self):
+        """
+        Checks a ValueError is raised if an invalid beam splitter convention is
+        set in bs.
+        """
+        circuit = CompiledCircuit(3)
+        with pytest.raises(ValueError):
+            circuit.add_bs(0, convention="Not valid")


### PR DESCRIPTION
This PR reworks how the circuit spec is defined. This was originally a list of component names and details, but over time this has become unintuitive and hard to decipher. Instead, each component in the circuit spec has been replaced with a data class, which makes it much easier to retrieve and utilise the component details. 

Also in this update, the circuit display spec has been removed, and instead the display class accesses required details from components directly. Which again, is intended to simplify the code.

All aspects of the code have been updated to account for this change, and some additional unit tests have also been added to ensure correct functionality of the circuit.