### PR TITLE
Display loss bugfix

### DIFF
--- a/lightworks/sdk/visualisation/draw_circuit_mpl.py
+++ b/lightworks/sdk/visualisation/draw_circuit_mpl.py
@@ -122,7 +122,7 @@ class DrawCircuitMPL:
                     spec.reflectivity, self.show_parameter_values
                 )
                 self._add_bs(spec.mode_1, spec.mode_2, reflectivity)
-            elif isinstance(spec, Loss):
+            elif isinstance(spec, Loss) and self.display_loss:
                 loss = process_parameter_value(
                     spec.loss, self.show_parameter_values
                 )

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -148,7 +148,7 @@ class DrawCircuitSVG:
                     spec.reflectivity, self.show_parameter_values
                 )
                 self._add_bs(spec.mode_1, spec.mode_2, reflectivity)
-            elif isinstance(spec, Loss):
+            elif isinstance(spec, Loss) and self.display_loss:
                 loss = process_parameter_value(
                     spec.loss, self.show_parameter_values
                 )


### PR DESCRIPTION
Fixed an issue with the display methods in which loss elements were always shown, regardless of the `display_loss` control.