### PR TITLE
Post-selection manager

### DIFF
--- a/docs/source/sdk_reference/utils.rst
+++ b/docs/source/sdk_reference/utils.rst
@@ -16,3 +16,11 @@ Utilities
 .. _db_loss_to_tr:
 
 .. autofunction:: lightworks.db_loss_to_transmission
+
+.. _post_selection:
+
+.. autoclass:: lightworks.PostSelection
+    :members:
+
+.. autoclass:: lightworks.PostSelectionFunction
+    :members:

--- a/lightworks/__init__.py
+++ b/lightworks/__init__.py
@@ -49,6 +49,8 @@ from .sdk.circuit import Circuit, Parameter, ParameterDict, Unitary
 from .sdk.optimisation import Optimisation
 from .sdk.state import State
 from .sdk.utils import (
+    PostSelection,
+    PostSelectionFunction,
     db_loss_to_transmission,
     random_permutation,
     random_unitary,
@@ -68,6 +70,6 @@ __all__ = [
     "Circuit", "Unitary", "Display", "State", "random_unitary",
     "random_permutation", "db_loss_to_transmission", "transmission_to_db_loss",
     "Parameter", "ParameterDict", "emulator", "qubit", "Optimisation",
-    "interferometers"
+    "interferometers", "PostSelection", "PostSelectionFunction",
 ]
 # fmt: on

--- a/lightworks/emulator/utils/__init__.py
+++ b/lightworks/emulator/utils/__init__.py
@@ -15,4 +15,5 @@
 # ruff: noqa: F401, F403
 
 from .exceptions import *
+from .post_selection_processing import process_post_selection
 from .state_utils import annotated_state_to_string, fock_basis

--- a/lightworks/emulator/utils/post_selection_processing.py
+++ b/lightworks/emulator/utils/post_selection_processing.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import FunctionType
+from typing import Callable
+
+from ...sdk.utils import PostSelectionFunction
+from ...sdk.utils.post_selection import DefaultPostSelection, PostSelectionType
+
+
+def process_post_selection(
+    post_selection: PostSelectionType | Callable | None,
+) -> PostSelectionType:
+    """
+    Takes a provided post-selection value and converts this into one of the
+    PostSelection objects with a validate method.
+
+    Args:
+
+        post_selection (PostSelectionType | Callable | None) : The
+            post-selection value to be processed. If a callable this will be
+            converted into the PostSelectionFunction object, otherwise if None
+            then the DefaultPostSelection object will be used.
+
+    Returns:
+
+        PostSelectionType : The created PostSelection object, if the original
+            value wasn't already one.
+
+    """
+    # Create always true post_select if one isn't provided
+    if post_selection is None:
+        post_selection = DefaultPostSelection()
+    if isinstance(post_selection, FunctionType):
+        post_selection = PostSelectionFunction(post_selection)
+    elif not isinstance(post_selection, PostSelectionType):
+        raise TypeError(
+            "Provided post_select value should be a function or PostSelection "
+            "object."
+        )
+    return post_selection

--- a/lightworks/sdk/utils/__init__.py
+++ b/lightworks/sdk/utils/__init__.py
@@ -23,3 +23,4 @@ from .matrix_utils import (
     random_unitary,
 )
 from .permutation_conversion import permutation_mat_from_swaps_dict
+from .post_selection import PostSelection, PostSelectionFunction

--- a/lightworks/sdk/utils/post_selection.py
+++ b/lightworks/sdk/utils/post_selection.py
@@ -1,0 +1,190 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from abc import ABCMeta, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from types import FunctionType
+from typing import Callable
+
+from ..state import State
+
+
+class ABCPostSelection(metaclass=ABCMeta):
+    """
+    Base class for post-selection object.
+    """
+
+    @abstractmethod
+    def validate(self, state: State) -> bool:
+        """Enforces all post-selection classes have the validate method."""
+
+
+class PostSelection(ABCPostSelection):
+    """
+    Post-selection
+
+    Args:
+
+        multi_rules (bool, optional) : Controls whether multiple rules can be
+            applied to a single mode.
+
+    """
+
+    def __init__(self, multi_rules: bool = False) -> None:
+        self.multi_rules = multi_rules
+        self.__rules: list[Rule] = []
+        self.__modes_with_rules: set[int] = set()
+
+    @property
+    def rules(self) -> list:
+        """
+        Returns currently applied post-selection rules.
+        """
+        return self.__rules
+
+    @property
+    def modes(self) -> list:
+        """
+        Returns modes on which rules are currently applied.
+        """
+        return sorted(self.__modes_with_rules)
+
+    def add(self, modes: int | tuple, n_photons: int | tuple) -> None:
+        """
+        Adds a post-selection rule across the provided modes, conditioning that
+        the total number of photons across the modes is equal to any of the
+        provided number of photons.
+
+        Args:
+
+            modes (int, tuple) : The modes across which post-selection should be
+                applied. This can be a singular mode provided as an integer or
+                a range of modes as a tuple.
+
+            n_photons (int, tuple) : The valid photon number totals across the
+                modes. This can be a singular integer value or a range of
+                allowable photon numbers.
+
+        """
+        modes = check_int_or_tuple(modes)
+        n_photons = check_int_or_tuple(n_photons)
+        # Check mode doesn't already have a rule if required
+        if not self.multi_rules:
+            for m in modes:
+                if m in self.__modes_with_rules:
+                    msg = (
+                        f"Provided mode ({m}) already has a post-selection "
+                        "rule applied. To allow this, set multi_rules attribute"
+                        " to True."
+                    )
+                    raise ValueError(msg)
+        self.__rules.append(Rule(modes, n_photons))
+        for m in modes:
+            if m < 0:
+                raise ValueError("Mode numbers cannot be negative.")
+            self.__modes_with_rules.add(m)
+
+    def validate(self, state: State) -> bool:
+        """
+        Validates whether a provided State meets the set post-selection
+        criteria.
+
+        Args:
+
+            state (State) : The state which is to be checked.
+
+        Returns:
+
+            bool : Indicates whether the provided State meets the post-selection
+                criteria.
+
+        """
+        return all(rule.validate(state) for rule in self.__rules)
+
+
+@dataclass(slots=True)
+class Rule:
+    """
+    Stores a post-selection rule for a number of modes and n_photons.
+    """
+
+    modes: tuple[int]
+    n_photons: tuple[int]
+
+    def as_tuple(self) -> tuple:
+        """Returns a tuple representation of the post-selection rule."""
+        return (self.modes, self.n_photons)
+
+    def validate(self, state: State) -> bool:
+        """Validates a provided state meets the post-selection rule."""
+        return sum(state[m] for m in self.modes) in self.n_photons
+
+
+class PostSelectionFunction(ABCPostSelection):
+    """
+    Allows for post-selection to be implemented with a provided function.
+    """
+
+    def __init__(self, function: Callable) -> None:
+        if not isinstance(function, FunctionType):
+            raise TypeError("Post-selection not a function.")
+        self.__function = function
+
+    def validate(self, state: State) -> bool:
+        """
+        Validates whether a provided State meets the set post-selection
+        criteria.
+
+        Args:
+
+            state (State) : The state which is to be checked.
+
+        Returns:
+
+            bool : Indicates whether the provided State meets the post-selection
+                criteria.
+
+        """
+        raise self.__function(state)
+
+
+def check_int_or_tuple(value: int | Sequence) -> tuple:
+    """
+    Process a provided value, if it is a sequence then it will check all values
+    are integers, otherwise it will validate the value and convert to a tuple.
+    """
+    if isinstance(value, Sequence):
+        value = list(value)
+        for i, v in enumerate(value):
+            value[i] = check_int(v)
+        return tuple(value)
+    value = check_int(value)
+    return (value,)
+
+
+def check_int(value: int) -> int:
+    """
+    Processes a provided single value, trying to convert to an integer if not
+    already and and then returning this.
+    """
+    if not isinstance(value, int):
+        if value == int(value):
+            value = int(value)
+        else:
+            raise ValueError(
+                "Provided value should be a tuple of integers or an integer."
+            )
+    return value

--- a/lightworks/sdk/utils/post_selection.py
+++ b/lightworks/sdk/utils/post_selection.py
@@ -81,6 +81,12 @@ class PostSelection(PostSelectionType):
         """
         modes = check_int_or_tuple(modes)
         n_photons = check_int_or_tuple(n_photons)
+        for values, msg in zip(
+            (modes, n_photons), ("Mode numbers", "Photon numbers")
+        ):
+            for v in values:
+                if v < 0:
+                    raise ValueError(msg + " cannot be negative.")
         # Check mode doesn't already have a rule if required
         if not self.multi_rules:
             for m in modes:
@@ -93,8 +99,6 @@ class PostSelection(PostSelectionType):
                     raise ValueError(msg)
         self.__rules.append(Rule(modes, n_photons))
         for m in modes:
-            if m < 0:
-                raise ValueError("Mode numbers cannot be negative.")
             self.__modes_with_rules.add(m)
 
     def validate(self, state: State) -> bool:

--- a/lightworks/sdk/utils/post_selection.py
+++ b/lightworks/sdk/utils/post_selection.py
@@ -22,7 +22,7 @@ from typing import Callable
 from ..state import State
 
 
-class ABCPostSelection(metaclass=ABCMeta):
+class PostSelectionType(metaclass=ABCMeta):
     """
     Base class for post-selection object.
     """
@@ -32,7 +32,7 @@ class ABCPostSelection(metaclass=ABCMeta):
         """Enforces all post-selection classes have the validate method."""
 
 
-class PostSelection(ABCPostSelection):
+class PostSelection(PostSelectionType):
     """
     Post-selection
 
@@ -133,7 +133,7 @@ class Rule:
         return sum(state[m] for m in self.modes) in self.n_photons
 
 
-class PostSelectionFunction(ABCPostSelection):
+class PostSelectionFunction(PostSelectionType):
     """
     Allows for post-selection to be implemented with a provided function.
     """
@@ -158,7 +158,19 @@ class PostSelectionFunction(ABCPostSelection):
                 criteria.
 
         """
-        raise self.__function(state)
+        return self.__function(state)
+
+
+class DefaultPostSelection(PostSelectionType):
+    """
+    Provides a default post-selection function which always returns True.
+    """
+
+    def validate(self, state: State) -> bool:  # noqa: ARG002
+        """
+        Will return True regardless of provided state.
+        """
+        return True
 
 
 def check_int_or_tuple(value: int | Sequence) -> tuple:

--- a/tests/emulator/cnot_test.py
+++ b/tests/emulator/cnot_test.py
@@ -17,7 +17,7 @@
 import pytest
 from numpy import arccos, pi
 
-from lightworks import Circuit, State, PostSelection
+from lightworks import Circuit, PostSelection, State
 from lightworks.emulator import Backend, Detector, Sampler, Source
 from lightworks.qubit import CNOT
 

--- a/tests/emulator/cnot_test.py
+++ b/tests/emulator/cnot_test.py
@@ -17,12 +17,39 @@
 import pytest
 from numpy import arccos, pi
 
-from lightworks import Circuit, State
+from lightworks import Circuit, State, PostSelection
 from lightworks.emulator import Backend, Detector, Sampler, Source
 from lightworks.qubit import CNOT
 
+heralds = [
+    lambda s: (
+        s[0] == 0 and s[5] == 0 and s[1] + s[2] == 1 and s[3] + s[4] == 1
+    ),
+    lambda s: (s[0] + s[1] == 1 and s[2] + s[3] == 1),
+]
+# Including heralds
+post_selection = PostSelection()
+post_selection.add(0, 0)
+post_selection.add(5, 0)
+post_selection.add((1, 2), 1)
+post_selection.add((3, 4), 1)
+# Excluding heralds
+post_selection2 = PostSelection()
+post_selection2.add((0, 1), 1)
+post_selection2.add((2, 3), 1)
 
-@pytest.mark.parametrize("backend", [Backend("permanent"), Backend("slos")])
+post_selects = [post_selection, post_selection2]
+
+
+@pytest.mark.parametrize(
+    ("backend", "post_selection"),
+    [
+        (Backend("permanent"), heralds),
+        (Backend("slos"), heralds),
+        (Backend("permanent"), post_selects),
+        (Backend("slos"), post_selects),
+    ],
+)
 class TestCNOT:
     """
     Samples from a non-heralded CNOT circuit with loss, imperfect source and
@@ -30,7 +57,7 @@ class TestCNOT:
     both permanent and slos backends.
     """
 
-    def test_cnot_sample_n_inputs(self, backend):
+    def test_cnot_sample_n_inputs(self, backend, post_selection):
         """
         Checks the correct output is produced from the CNOT gate when sampling
         N inputs from the system. Note, very occasionally this test may fail
@@ -67,19 +94,14 @@ class TestCNOT:
             detector=detector,
             backend=backend,
         )
-        # Can then define the heralding required to get the correct output and
-        # generate a set of samples
-        herald = lambda s: (
-            s[0] == 0 and s[5] == 0 and s[1] + s[2] == 1 and s[3] + s[4] == 1
-        )
-        results = sampler.sample_N_inputs(20000, post_select=herald)
+        results = sampler.sample_N_inputs(20000, post_select=post_selection[0])
         # We expect the state |11> (|0,0,1,0,1,0> in mode language) with
         # reasonable fidelity, so we will assert this is measured for > 80% of
         # the total samples which met the herald condition
         eff = results[State([0, 0, 1, 0, 1, 0])] / sum(results.values())
         assert eff > 0.8
 
-    def test_cnot_sample_n_outputs(self, backend):
+    def test_cnot_sample_n_outputs(self, backend, post_selection):
         """
         Checks the correct output is produced from the CNOT gate when sampling
         N outputs from the system. Note, very occasionally this test may fail
@@ -116,19 +138,14 @@ class TestCNOT:
             detector=detector,
             backend=backend,
         )
-        # Can then define the heralding required to get the correct output and
-        # generate a set of samples
-        herald = lambda s: (
-            s[0] == 0 and s[5] == 0 and s[1] + s[2] == 1 and s[3] + s[4] == 1
-        )
-        results = sampler.sample_N_outputs(20000, post_select=herald)
+        results = sampler.sample_N_outputs(20000, post_select=post_selection[0])
         # We expect the state |11> (|0,0,1,0,1,0> in mode language) with
         # reasonable fidelity, so we will assert this is measured for > 80% of
         # the total samples which met the herald condition
         eff = results[State([0, 0, 1, 0, 1, 0])] / 20000
         assert eff > 0.8
 
-    def test_cnot_sample_n_inputs_built_in(self, backend):
+    def test_cnot_sample_n_inputs_built_in(self, backend, post_selection):
         """
         Checks the correct output is produced from the built-in CNOT gate when
         sampling N inputs from the system. Note, very occasionally this test
@@ -148,17 +165,14 @@ class TestCNOT:
             detector=detector,
             backend=backend,
         )
-        # Can then define the post-selection required to get the correct output
-        # and generate a set of samples
-        post_select = lambda s: (s[0] + s[1] == 1 and s[2] + s[3] == 1)
-        results = sampler.sample_N_inputs(20000, post_select=post_select)
+        results = sampler.sample_N_inputs(20000, post_select=post_selection[1])
         # We expect the state |11> (|0,1,0,1> in mode language) with
         # reasonable fidelity, so we will assert this is measured for > 80% of
         # the total samples which met the herald condition
         eff = results[State([0, 1, 0, 1])] / sum(results.values())
         assert eff > 0.8
 
-    def test_cnot_sample_n_outputs_built_in(self, backend):
+    def test_cnot_sample_n_outputs_built_in(self, backend, post_selection):
         """
         Checks the correct output is produced from the built-in CNOT gate when
         sampling N outputs from the system. Note, very occasionally this test
@@ -178,10 +192,7 @@ class TestCNOT:
             detector=detector,
             backend=backend,
         )
-        # Can then define the post-selection required to get the correct output
-        # and generate a set of samples
-        post_select = lambda s: (s[0] + s[1] == 1 and s[2] + s[3] == 1)
-        results = sampler.sample_N_outputs(20000, post_select=post_select)
+        results = sampler.sample_N_outputs(20000, post_select=post_selection[1])
         # We expect the state |11> (|0,1,0,1> in mode language) with
         # reasonable fidelity, so we will assert this is measured for > 80% of
         # the total samples which met the herald condition

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -14,7 +14,14 @@
 
 import pytest
 
-from lightworks import Circuit, Parameter, State, Unitary, random_unitary
+from lightworks import (
+    Circuit,
+    Parameter,
+    PostSelection,
+    State,
+    Unitary,
+    random_unitary,
+)
 from lightworks.emulator import (
     Backend,
     Detector,
@@ -585,9 +592,10 @@ class TestSamplerCalculationBackends:
         sampler = Sampler(
             circuit, State([1, 1, 0, 1, 0, 0]), backend=backend, source=source
         )
-        results = sampler.sample_N_outputs(
-            50000, post_select=lambda s: s[1] == 1 and s[3] == 0
-        )
+        post_select = PostSelection()
+        post_select.add(1, 1)
+        post_select.add(3, 0)
+        results = sampler.sample_N_outputs(50000, post_select=post_select)
         # Then add and re-sample
         circuit.herald(1, 0, 1)
         circuit.herald(0, 2, 3)

--- a/tests/sdk/util_test.py
+++ b/tests/sdk/util_test.py
@@ -298,6 +298,30 @@ class TestPostSelection:
         p.add((4,), 1)
         assert p.modes == [1, 2, 3, 4]
 
+    @pytest.mark.parametrize(
+        ("modes", "photons"),
+        [
+            (1, 1),
+            ((1,), (1,)),
+            ((1, 2), (1,)),
+            ((1,), (1, 2)),
+            ((2, 3), (1, 2)),
+        ],
+    )
+    def test_post_selection_rules(self, modes, photons):
+        """
+        Checks that post-selection rules content is correct.
+        """
+        p = PostSelection()
+        p.add(modes, photons)
+        rules = p.rules
+        if not isinstance(modes, tuple):
+            modes = (modes,)
+        if not isinstance(photons, tuple):
+            photons = (photons,)
+        assert rules[0].modes == modes
+        assert rules[0].n_photons == photons
+
     @pytest.mark.parametrize("value", [-1, 0.5, ([1, 2],), "1.1"])
     def test_invalid_mode_values(self, value):
         """

--- a/tests/sdk/util_test.py
+++ b/tests/sdk/util_test.py
@@ -117,7 +117,7 @@ class TestUtils:
     def test_add_mode_to_unitary_value(self, mode):
         """
         Checks that add_mode_to_unitary function works correctly for a variety
-        of positions, producinh .
+        of positions, producing a value of 1 in the expected position.
         """
         unitary = random_unitary(6)
         new_unitary = add_mode_to_unitary(unitary, mode)

--- a/tests/sdk/util_test.py
+++ b/tests/sdk/util_test.py
@@ -298,6 +298,19 @@ class TestPostSelection:
         p.add((4,), 1)
         assert p.modes == [1, 2, 3, 4]
 
+    def test_post_selection_duplicates(self):
+        """
+        Checks that post-selection modes attribute is able to correctly return
+        the correct values when a mode is used more than once
+        """
+        p = PostSelection(multi_rules=True)
+        p.add(1, 1)
+        assert p.modes == [1]
+        p.add((2, 1), 1)
+        assert p.modes == [1, 2]
+        p.add((2,), 1)
+        assert p.modes == [1, 2]
+
     @pytest.mark.parametrize(
         ("modes", "photons"),
         [
@@ -321,6 +334,16 @@ class TestPostSelection:
             photons = (photons,)
         assert rules[0].modes == modes
         assert rules[0].n_photons == photons
+
+    def test_post_selection_rules_length(self):
+        """
+        Confirms that rules property returns a list of the correct length.
+        """
+        p = PostSelection(multi_rules=True)
+        p.add((0, 1), 2)
+        p.add((0, 1), 2)
+        p.add((2, 3), 1)
+        assert len(p.rules) == 3
 
     @pytest.mark.parametrize("value", [-1, 0.5, ([1, 2],), "1.1"])
     def test_invalid_mode_values(self, value):


### PR DESCRIPTION
Added a new set of objects which are designed for standardising and managing post-selection across Lightworks. The core of these is `Post-Selection` which allows for criteria to be built up across a set of mode/photon numbers and `PostSelectionFunction` which supports provision of a function to apply post-selection. Unit tests have also been included for all tests and some sampler tests have been modified to use the new function.

The `Sampler` + `QuickSampler` have been updated to support post-selection in this way, but currently the `post_select` option of these objects can still be specified as a function directly, meaning it doesn't break compatibility. It is not intended that this will change.