### PR TITLE
Interferometer phase_offset property

### DIFF
--- a/lightworks/interferometers/error_model.py
+++ b/lightworks/interferometers/error_model.py
@@ -27,6 +27,7 @@ class ErrorModel:
     def __init__(self) -> None:
         self.bs_reflectivity = Constant(0.5)
         self.loss = Constant(0)
+        self.phase_offset = Constant(0)
 
         return
 
@@ -61,6 +62,17 @@ class ErrorModel:
             raise TypeError("loss should be a distribution object.")
         self._loss = distribution
 
+    @property
+    def phase_offset(self) -> Distribution:
+        """Returns currently in use phase_offset value distribution."""
+        return self._phase_offset
+
+    @phase_offset.setter
+    def phase_offset(self, distribution: Distribution) -> None:
+        if not isinstance(distribution, Distribution):
+            raise TypeError("phase_offset should be a distribution object.")
+        self._phase_offset = distribution
+
     def get_bs_reflectivity(self) -> int | float:
         """
         Returns a value for beam splitter reflectivity, which depends on the
@@ -70,10 +82,17 @@ class ErrorModel:
 
     def get_loss(self) -> int | float:
         """
-        Returns a value for loss which depends on the configuration of the error
-        model.
+        Returns a value for loss, which depends on the configuration of the
+        error model.
         """
         return self._loss.value()
+
+    def get_phase_offset(self) -> int | float:
+        """
+        Returns a value for phase offset, which depends on the configuration of
+        the error model.
+        """
+        return self._phase_offset.value()
 
     def _set_random_seed(self, r_seed: int | None) -> None:
         """
@@ -84,11 +103,9 @@ class ErrorModel:
         # different values
         rng = random.default_rng(seed)
         # Set random seed in each property if present
-        for prop in [self._bs_reflectivity, self._loss]:
+        for prop in [self._bs_reflectivity, self._loss, self._phase_offset]:
             if hasattr(prop, "set_random_seed") and callable(
                 prop.set_random_seed
             ):
-                if seed is not None:
-                    mod_seed = rng.integers(0, 2**31)
-                    seed = seed * mod_seed
+                seed = rng.integers(2**31 - 1)
                 prop.set_random_seed(seed)

--- a/lightworks/interferometers/error_model.py
+++ b/lightworks/interferometers/error_model.py
@@ -107,5 +107,6 @@ class ErrorModel:
             if hasattr(prop, "set_random_seed") and callable(
                 prop.set_random_seed
             ):
-                seed = rng.integers(2**31 - 1)
+                if seed is not None:
+                    seed = rng.integers(2**31 - 1)
                 prop.set_random_seed(seed)

--- a/lightworks/interferometers/reck.py
+++ b/lightworks/interferometers/reck.py
@@ -71,8 +71,14 @@ class Reck:
         # Invert unitary so reck layout starts with fewest elements on mode 0
         unitary = np.flip(circuit.U, axis=(0, 1))
         phase_map, end_phases = reck_decomposition(unitary)
-        phase_map = {k: v % (2 * np.pi) for k, v in phase_map.items()}
-        end_phases = [p % (2 * np.pi) for p in end_phases]
+        phase_map = {
+            k: (v + self.error_model.get_phase_offset()) % (2 * np.pi)
+            for k, v in phase_map.items()
+        }
+        end_phases = [
+            (p + self.error_model.get_phase_offset()) % (2 * np.pi)
+            for p in end_phases
+        ]
 
         # Build circuit with required mode number
         n_modes = circuit.n_modes

--- a/tests/interferometers/error_model_test.py
+++ b/tests/interferometers/error_model_test.py
@@ -109,6 +109,22 @@ class TestErrorModel:
         with pytest.raises(TypeError):
             em.loss = value
 
+    def test_phase_offset_is_distribution(self):
+        """
+        Checks that return by phase_offset property is a Distribution object.
+        """
+        assert isinstance(ErrorModel().phase_offset, Distribution)
+
+    @pytest.mark.parametrize("value", [1, True, None, "Distribution"])
+    def test_phase_offset_enforces_distribution(self, value):
+        """
+        Checks that setting phase_offset setting enforces that the value is a
+        Distribution object.
+        """
+        em = ErrorModel()
+        with pytest.raises(TypeError):
+            em.phase_offset = value
+
     @pytest.mark.parametrize("param", ["bs_reflectivity", "loss"])
     def test_parameters_in_string_and_repr(self, param):
         """
@@ -118,3 +134,21 @@ class TestErrorModel:
         em = ErrorModel()
         assert param in str(em)
         assert param in repr(em)
+
+    @pytest.mark.parametrize(
+        "value", ["bs_reflectivity", "loss", "phase_offset"]
+    )
+    def test_random_seeding(self, value):
+        """
+        Checks that set random seed produces different values when two
+        quantities are assigned to identical distributions.
+        """
+        em = ErrorModel()
+        setattr(em, value, Gaussian(0.5, 0.1))
+        # Set seed and get value twice
+        em._set_random_seed(11)
+        v1 = getattr(em, value).value()
+        em._set_random_seed(11)
+        v2 = getattr(em, value).value()
+        # Check equivalence
+        assert v1 == v2

--- a/tests/interferometers/interferometer_test.py
+++ b/tests/interferometers/interferometer_test.py
@@ -48,6 +48,7 @@ class TestReck:
         emodel = ErrorModel()
         emodel.bs_reflectivity = Gaussian(0.5, 0.02, min_value=0, max_value=1)
         emodel.loss = TopHat(0.1, 0.2)
+        emodel.phase_offset = Gaussian(0, 0.02)
         r = Reck(emodel)
         # Create two mapped circuits
         mapped_circ = r.map(test_circ)
@@ -66,6 +67,7 @@ class TestReck:
         emodel = ErrorModel()
         emodel.bs_reflectivity = Gaussian(0.5, 0.02, min_value=0, max_value=1)
         emodel.loss = TopHat(0.1, 0.2)
+        emodel.phase_offset = Gaussian(0, 0.02)
         r = Reck(emodel)
         # Set seed and create two mapped circuits
         mapped_circ = r.map(test_circ, seed=12)


### PR DESCRIPTION
# Summary

Implemented a phase_offset property in the ErrorModel and Reck interferometer, allowing for introduction of random variation in the setting of elements. Inaccuracy of the system setting is a typical source for error in these systems.

## Full list of changes

- Added phase_offset property in the ErrorModel.
- Included a modification to all phases in the Reck interferometer by this value.
- Fixed a bug which could cause integer overflows when setting the random seed, this resulted from how the seed was modified to ensure variation between properties.
