### PR TITLE
Qiskit conversion post selection support

### DIFF
--- a/lightworks/qubit/converter/qiskit_convert.py
+++ b/lightworks/qubit/converter/qiskit_convert.py
@@ -132,10 +132,18 @@ class QiskitConverter:
                 self._add_single_qubit_gate(gate, *qubits)
             # Two Qubit Gates
             elif len(qubits) == 2:
-                self._add_two_qubit_gate(gate, *qubits, post_select[i])
+                self._add_two_qubit_gate(
+                    gate,
+                    *qubits,  # type: ignore[call-arg]
+                    post_select[i],
+                )
             # Three Qubit Gates
             elif len(qubits) == 3:
-                self._add_three_qubit_gate(gate, *qubits, post_select[i])
+                self._add_three_qubit_gate(
+                    gate,
+                    *qubits,  # type: ignore[call-arg]
+                    post_select[i],
+                )
             # Limit to three qubit gates
             else:
                 raise ValueError("Gates with more than 3 qubits not supported.")
@@ -275,7 +283,7 @@ def post_selection_analyzer(qc: QuantumCircuit) -> tuple[list[bool], list[int]]:
 
     """
     # First extract all qubit data from the circuit
-    gate_qubits = []
+    gate_qubits: list[list[int] | None] = []
     for inst in qc.data:
         if inst.operation.num_qubits >= 2:
             gate_qubits.append(

--- a/lightworks/qubit/converter/qiskit_convert.py
+++ b/lightworks/qubit/converter/qiskit_convert.py
@@ -18,6 +18,8 @@ from ...sdk.circuit import Circuit
 from ..gates import (
     CCNOT,
     CCZ,
+    CNOT,
+    CZ,
     SWAP,
     CNOT_Heralded,
     CZ_Heralded,
@@ -39,6 +41,7 @@ SINGLE_QUBIT_GATES_MAP = {
 }
 
 TWO_QUBIT_GATES_MAP = {"cx": CNOT_Heralded, "cz": CZ_Heralded, "swap": SWAP}
+TWO_QUBIT_GATES_MAP_PS = {"cx": CNOT, "cz": CZ}
 
 THREE_QUBIT_GATES_MAP = {"ccx": CCNOT, "ccz": CCZ}
 
@@ -49,21 +52,26 @@ ALLOWED_GATES = [
 ]
 
 
-def qiskit_converter(circuit: QuantumCircuit) -> Circuit:
+def qiskit_converter(
+    circuit: QuantumCircuit, allow_post_selection: bool = False
+) -> Circuit:
     """
     Performs conversion of a provided qiskit QuantumCircuit into a photonic
     circuit within Lightworks.
 
     Args:
 
-        circuit (QuantumCircuit) : The qiskit circuit to be converted,
+        circuit (QuantumCircuit) : The qiskit circuit to be converted.
+
+        allow_post_selection (bool, optional) : Controls whether post-selected
+            gates can be utilised within the circuit.
 
     Returns:
 
         Circuit : The created circuit within Lightworks.
 
     """
-    converter = QiskitConverter()
+    converter = QiskitConverter(allow_post_selection)
     return converter.convert(circuit)
 
 
@@ -71,7 +79,16 @@ class QiskitConverter:
     """
     Manages conversion between qiskit and lightworks circuit, adding each of the
     qubit gates into a created circuit object.
+
+    Args:
+
+        allow_post_selection (bool, optional) : Controls whether post-selected
+            gates can be utilised within the circuit.
+
     """
+
+    def __init__(self, allow_post_selection: bool = False) -> None:
+        self.allow_post_selection = allow_post_selection
 
     def convert(self, q_circuit: QuantumCircuit) -> Circuit:
         """
@@ -80,7 +97,7 @@ class QiskitConverter:
 
         Args:
 
-            q_circuit (QuantumCircuit) : The qiskit circuit to be converted,
+            q_circuit (QuantumCircuit) : The qiskit circuit to be converted.
 
         Returns:
 

--- a/tests/qubit/converter_test.py
+++ b/tests/qubit/converter_test.py
@@ -56,7 +56,7 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(3)
         getattr(circ, gate)(0, 1, 2)
-        qiskit_converter(circ)
+        qiskit_converter(circ, allow_post_selection=True)
 
     def test_four_qubit_gate(self):
         """
@@ -74,7 +74,7 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(1)
         circ.x(0)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ)
 
         sim = Simulator(conv_circ)
         results = sim.simulate(State([1, 0]), State([0, 1]))
@@ -88,13 +88,65 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(2)
         circ.cx(0, 1)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ)
 
         sim = Simulator(conv_circ)
         results = sim.simulate(State([0, 1, 1, 0]), State([0, 1, 0, 1]))
         assert abs(
             results[State([0, 1, 1, 0]), State([0, 1, 0, 1])]
         ) ** 2 == pytest.approx(1 / 16, 1e-6)
+
+    def test_cascaded_cnot(self):
+        """
+        Checks operation of two cascaded qubit CNOT gate produces output as
+        expected.
+        """
+        circ = QuantumCircuit(3)
+        circ.cx(0, 1)
+        circ.cx(1, 2)
+        conv_circ, _ = qiskit_converter(circ)
+
+        sim = Simulator(conv_circ)
+        results = sim.simulate(
+            State([0, 1, 1, 0, 1, 0]), State([0, 1, 0, 1, 0, 1])
+        )
+        assert abs(
+            results[State([0, 1, 1, 0, 1, 0]), State([0, 1, 0, 1, 0, 1])]
+        ) ** 2 == pytest.approx(1 / 16**2, 1e-6)
+
+    def test_cnot_post_selected(self):
+        """
+        Checks operation of two qubit post-selected CNOT gate produces output as
+        expected.
+        """
+        circ = QuantumCircuit(2)
+        circ.cx(0, 1)
+        conv_circ, _ = qiskit_converter(circ, allow_post_selection=True)
+
+        sim = Simulator(conv_circ)
+        results = sim.simulate(State([0, 1, 1, 0]), State([0, 1, 0, 1]))
+        assert abs(
+            results[State([0, 1, 1, 0]), State([0, 1, 0, 1])]
+        ) ** 2 == pytest.approx(1 / 9, 1e-6)
+
+    def test_cascaded_cnot_post_selected(self):
+        """
+        Checks operation of two cascaded qubit post-selected CNOT gate produces
+        output as expected. Both gates should be post-selected, so the success
+        probability should be 1/9*1/9 = 1/81.
+        """
+        circ = QuantumCircuit(3)
+        circ.cx(0, 1)
+        circ.cx(1, 2)
+        conv_circ, _ = qiskit_converter(circ, allow_post_selection=True)
+
+        sim = Simulator(conv_circ)
+        results = sim.simulate(
+            State([0, 1, 1, 0, 1, 0]), State([0, 1, 0, 1, 0, 1])
+        )
+        assert abs(
+            results[State([0, 1, 1, 0, 1, 0]), State([0, 1, 0, 1, 0, 1])]
+        ) ** 2 == pytest.approx(1 / 81, 1e-6)
 
     def test_bell_state(self):
         """
@@ -104,7 +156,7 @@ class TestQiskitConversion:
         circ = QuantumCircuit(2)
         circ.h(0)
         circ.cx(0, 1)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ)
 
         sim = Simulator(conv_circ)
         outputs = [State([1, 0, 1, 0]), State([0, 1, 0, 1])]
@@ -121,7 +173,7 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(2)
         circ.cx(1, 0)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ)
 
         sim = Simulator(conv_circ)
         results = sim.simulate(State([1, 0, 0, 1]), State([0, 1, 0, 1]))
@@ -136,7 +188,7 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(3)
         circ.cx(0, 2)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ)
 
         sim = Simulator(conv_circ)
         results = sim.simulate(
@@ -153,7 +205,7 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(3)
         circ.cx(2, 0)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ)
 
         sim = Simulator(conv_circ)
         results = sim.simulate(
@@ -169,7 +221,7 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(3)
         circ.ccx(0, 1, 2)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ, allow_post_selection=True)
 
         sim = Simulator(conv_circ)
         results = sim.simulate(
@@ -185,7 +237,7 @@ class TestQiskitConversion:
         """
         circ = QuantumCircuit(3)
         circ.swap(0, 2)
-        conv_circ = qiskit_converter(circ)
+        conv_circ, _ = qiskit_converter(circ)
 
         sim = Simulator(conv_circ)
         results = sim.simulate(


### PR DESCRIPTION
# Summary

Adds support for post-selected gates in `qiskit_converter`. These gates are often more resource efficient than their heralded equivalents, at the expense of requiring post-processing on the results. It can be enabled with the `allow_post_selection` setting.

A basic algorithm has been introduced to identify post-selection compatibility, as it is possible to produce incorrect results when cascading too many post-selected gates. This algorithm will reduce rather than minimise heralded gates.

## Full list of changes

- Added `allow_post_selection` setting to `qiskit_converter`.
- Included algorithm for identifying gates which are compatible with post-selection.
- Modified three qubit gate logic to enforce that this can only be added with post-selection.
- Added return of post-selection rules object from the converter function. This object should be directly passable to `Sampler` & `QuickSampler` for creation of the correct transformation.