### PR TITLE
qiskit_converter bugfix

### DIFF
--- a/lightworks/qubit/converter/qiskit_convert.py
+++ b/lightworks/qubit/converter/qiskit_convert.py
@@ -301,7 +301,7 @@ def post_selection_analyzer(qc: QuantumCircuit) -> tuple[list[bool], list[int]]:
     for gate in reversed(gate_qubits):
         if gate is None:
             post_selection.append(False)
-            break
+            continue
         can_ps = not all(q in has_ps for q in gate)
         post_selection.append(can_ps)
         has_ps += gate

--- a/tests/qubit/converter_test.py
+++ b/tests/qubit/converter_test.py
@@ -341,6 +341,6 @@ def build_random_qiskit_circuit(n_qubits):
     for _i in range(randint(10, 20)):
         gate = choice(gates)
         # Create unique list of qubits for each gate
-        qubits = sample(range(0, n_qubits), len(gate))
+        qubits = sample(range(n_qubits), len(gate))
         getattr(circuit, gate)(*qubits)
     return circuit


### PR DESCRIPTION
# Summary

Fixes a bug in which the qiskit_converter could fail when many gates were used. This resulted from a break statement which should have been continue. Also added some additional unit tests to catch this issue.
