### PR TITLE
Transmission to loss switch in conversion functions

### DIFF
--- a/docs/source/sdk/circuit.rst
+++ b/docs/source/sdk/circuit.rst
@@ -94,11 +94,11 @@ When using the emulator to simulate a circuit, it is also possible to include lo
     circuit.bs(1, reflectivity = 0.4, convention = "H", loss = 0.3)
 
 .. warning:: 
-    All losses in Lightworks should be provided as a decimal loss value, meaning loss = 0 corresponds to a ideal non-lossy component and loss = 1 will block all photons on a mode. It is also possible to specify loss in terms of dB using the include ``db_loss_to_transmission`` function, for example, to include a 3 dB loss the following would be valid, noting that ``1 - transmission`` is used to convert from transmission to loss.
+    All losses in Lightworks should be provided as a decimal loss value, meaning loss = 0 corresponds to a ideal non-lossy component and loss = 1 will block all photons on a mode. It is also possible to specify loss in terms of dB using the include ``db_loss_to_decimal`` function, for example, to include a 3 dB loss the following would be valid.
 
   .. code-block:: Python
 
-    circuit.bs(1, reflectivity = 0.4, convention = "H", loss = 1 - lw.db_loss_to_transmission(3))
+    circuit.bs(1, reflectivity = 0.4, convention = "H", loss = 1 - lw.db_loss_to_decimal(3))
 
 .. _phaseshifter:
 

--- a/docs/source/sdk/utilities.rst
+++ b/docs/source/sdk/utilities.rst
@@ -32,26 +32,26 @@ Generates an NxN permutation matrix, which is a unitary matrix with only values 
     # Create 8x8 matrix with random seed to return the same matrix
     U = lw.random_permutation(8, seed = 4)
 
-:func:`lightworks.db_loss_to_transmission`
+:func:`lightworks.db_loss_to_decimal`
 ------------------------------------------
 
-Converts a positive dB loss into a decimal transmission value.
+Converts a positive dB loss into a decimal loss value, which can be used with the circuit loss elements.
 
 .. code-block:: Python
 
-    # Convert 3dB loss into transmission
-    transmission = lw.db_loss_to_transmission(3)
-    print(transmission)
+    # Convert 3dB loss into decimal
+    loss = lw.db_loss_to_decimal(3)
+    print(loss)
     # Output: 0.5011872336272722
 
-:func:`lightworks.transmission_to_db_loss`
+:func:`lightworks.decimal_to_db_loss`
 ------------------------------------------
 
-Converts a decimal transmission value into a positive dB loss, which can be used with the circuit loss elements.
+Converts a decimal loss value into a positive dB loss.
 
 .. code-block:: Python
 
-    # Convert 70% transmission into loss 
-    loss = lw.transmission_to_db_loss(0.7)
+    # Convert 30% loss into dB value 
+    loss = lw.decimal_to_db_loss(0.3)
     print(loss)
     # Output: 1.5490195998574319

--- a/docs/source/sdk/utilities.rst
+++ b/docs/source/sdk/utilities.rst
@@ -42,7 +42,7 @@ Converts a positive dB loss into a decimal loss value, which can be used with th
     # Convert 3dB loss into decimal
     loss = lw.db_loss_to_decimal(3)
     print(loss)
-    # Output: 0.5011872336272722
+    # Output: 0.49881276637272776
 
 :func:`lightworks.decimal_to_db_loss`
 ------------------------------------------

--- a/docs/source/sdk_reference/utils.rst
+++ b/docs/source/sdk_reference/utils.rst
@@ -11,13 +11,13 @@ Utilities
 
 .. _tr_to_db_loss:
 
-.. autofunction:: lightworks.transmission_to_db_loss
-
-.. _db_loss_to_tr:
-
-.. autofunction:: lightworks.db_loss_to_transmission
+.. autofunction:: lightworks.db_loss_to_decimal
 
 .. _post_selection:
+
+.. autofunction:: lightworks.decimal_to_db_loss
+
+.. _db_loss_to_tr:
 
 .. autoclass:: lightworks.PostSelection
     :members:

--- a/lightworks/__init__.py
+++ b/lightworks/__init__.py
@@ -51,10 +51,10 @@ from .sdk.state import State
 from .sdk.utils import (
     PostSelection,
     PostSelectionFunction,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
+    decimal_to_db_loss,
     random_permutation,
     random_unitary,
-    transmission_to_db_loss,
 )
 from .sdk.utils.exceptions import *
 from .sdk.visualisation import Display
@@ -68,7 +68,7 @@ except ModuleNotFoundError:
 # fmt: off
 __all__ = [
     "Circuit", "Unitary", "Display", "State", "random_unitary",
-    "random_permutation", "db_loss_to_transmission", "transmission_to_db_loss",
+    "random_permutation", "db_loss_to_decimal", "decimal_to_db_loss",
     "Parameter", "ParameterDict", "emulator", "qubit", "Optimisation",
     "interferometers", "PostSelection", "PostSelectionFunction",
 ]

--- a/lightworks/sdk/utils/__init__.py
+++ b/lightworks/sdk/utils/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .conversion import db_loss_to_transmission, transmission_to_db_loss
+from .conversion import db_loss_to_decimal, decimal_to_db_loss
 from .exceptions import *
 from .heralding_utils import add_heralds_to_state, remove_heralds_from_state
 from .matrix_utils import (

--- a/lightworks/sdk/utils/conversion.py
+++ b/lightworks/sdk/utils/conversion.py
@@ -20,11 +20,10 @@ emulator.
 from math import log10
 
 
-def db_loss_to_transmission(loss: float) -> float:
+def db_loss_to_decimal(loss: float) -> float:
     """
-    Function to convert from a given dB loss into the equivalent transmission
-    value as a percentage. Note this function does not support conversion of
-    gain values.
+    Function to convert from a given dB loss into the equivalent loss value in
+    decimal form. Note this function does not support conversion of gain values.
 
     Args:
 
@@ -32,23 +31,23 @@ def db_loss_to_transmission(loss: float) -> float:
 
     Returns:
 
-        float : The calculated transmission as a decimal.
+        float : The calculated loss as a decimal.
 
     """
     # Standardize loss format
     loss = -abs(loss)
-    return 10 ** (loss / 10)
+    return 1 - 10 ** (loss / 10)
 
 
-def transmission_to_db_loss(transmission: float) -> float:
+def decimal_to_db_loss(loss: float) -> float:
     """
-    Function to convert from a transmission into dB loss. This dB loss will be
+    Function to convert from a decimal into dB loss. This dB loss will be
     returned as a positive value.
 
     Args:
 
-        transmission (float) : The transmission value as a decimal, this should
-            be in the range (0,1].
+        loss (float) : The loss value as a decimal, this should be in the range
+            [0,1).
 
     Returns:
 
@@ -56,9 +55,9 @@ def transmission_to_db_loss(transmission: float) -> float:
 
     Raises:
 
-        ValueError: Raised in cases where transmission is not in range (0,1].
+        ValueError: Raised in cases where transmission is not in range [0,1).
 
     """
-    if transmission <= 0 or transmission > 1:
-        raise ValueError("Transmission value should be in range (0,1].")
-    return abs(10 * log10(transmission))
+    if loss < 0 or loss >= 1:
+        raise ValueError("Transmission value should be in range [0,1).")
+    return abs(10 * log10(1 - loss))

--- a/tests/emulator/analyzer_test.py
+++ b/tests/emulator/analyzer_test.py
@@ -20,7 +20,7 @@ from lightworks import (
     PostSelection,
     State,
     Unitary,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
     random_unitary,
 )
 from lightworks.emulator import Analyzer
@@ -41,13 +41,9 @@ class TestAnalyzer:
             self.circuit.bs(m)
             self.circuit.ps(m + 1, phi=3 * i)
             # lossy circuit
-            self.lossy_circuit.bs(
-                m, loss=1 - db_loss_to_transmission(1 + 0.2 * i)
-            )
+            self.lossy_circuit.bs(m, loss=db_loss_to_decimal(1 + 0.2 * i))
             self.lossy_circuit.ps(m, phi=i)
-            self.lossy_circuit.bs(
-                m, loss=1 - db_loss_to_transmission(0.6 + 0.1 * i)
-            )
+            self.lossy_circuit.bs(m, loss=db_loss_to_decimal(0.6 + 0.1 * i))
             self.lossy_circuit.ps(m + 1, phi=3 * i)
 
     def test_hom(self):

--- a/tests/emulator/quicksampler_test.py
+++ b/tests/emulator/quicksampler_test.py
@@ -19,7 +19,7 @@ from lightworks import (
     Parameter,
     State,
     Unitary,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
     random_unitary,
 )
 from lightworks.emulator import ModeMismatchError, QuickSampler, Sampler
@@ -114,13 +114,13 @@ class TestQuickSampler:
         a lossy circuit is correct.
         """
         circuit = Circuit(4)
-        circuit.bs(0, loss=1 - db_loss_to_transmission(1.3))
-        circuit.bs(2, loss=1 - db_loss_to_transmission(2))
-        circuit.ps(1, 0.7, loss=1 - db_loss_to_transmission(0.5))
-        circuit.ps(3, 0.6, loss=1 - db_loss_to_transmission(0.5))
-        circuit.bs(1, loss=1 - db_loss_to_transmission(1.3))
-        circuit.bs(2, loss=1 - db_loss_to_transmission(2))
-        circuit.ps(1, 0.5, loss=1 - db_loss_to_transmission(0.5))
+        circuit.bs(0, loss=db_loss_to_decimal(1.3))
+        circuit.bs(2, loss=db_loss_to_decimal(2))
+        circuit.ps(1, 0.7, loss=db_loss_to_decimal(0.5))
+        circuit.ps(3, 0.6, loss=db_loss_to_decimal(0.5))
+        circuit.bs(1, loss=db_loss_to_decimal(1.3))
+        circuit.bs(2, loss=db_loss_to_decimal(2))
+        circuit.ps(1, 0.5, loss=db_loss_to_decimal(0.5))
         sampler = QuickSampler(
             circuit,
             State([1, 0, 1, 0]),

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -20,7 +20,7 @@ from lightworks import (
     PostSelection,
     State,
     Unitary,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
     random_unitary,
 )
 from lightworks.emulator import (
@@ -371,13 +371,13 @@ class TestSamplerCalculationBackends:
         """
         # Build circuit
         circuit = Circuit(4)
-        circuit.bs(0, loss=1 - db_loss_to_transmission(1))
-        circuit.bs(2, loss=1 - db_loss_to_transmission(2))
-        circuit.ps(1, 0.3, loss=1 - db_loss_to_transmission(0.5))
-        circuit.ps(3, 0.3, loss=1 - db_loss_to_transmission(0.5))
-        circuit.bs(1, loss=1 - db_loss_to_transmission(1))
-        circuit.bs(2, loss=1 - db_loss_to_transmission(2))
-        circuit.ps(1, 0.3, loss=1 - db_loss_to_transmission(0.5))
+        circuit.bs(0, loss=db_loss_to_decimal(1))
+        circuit.bs(2, loss=db_loss_to_decimal(2))
+        circuit.ps(1, 0.3, loss=db_loss_to_decimal(0.5))
+        circuit.ps(3, 0.3, loss=db_loss_to_decimal(0.5))
+        circuit.bs(1, loss=db_loss_to_decimal(1))
+        circuit.bs(2, loss=db_loss_to_decimal(2))
+        circuit.ps(1, 0.3, loss=db_loss_to_decimal(0.5))
         # Sample from circuit
         sampler = Sampler(circuit, State([1, 0, 1, 0]), backend=backend)
         p = sampler.probability_distribution[State([0, 1, 1, 0])]
@@ -392,13 +392,13 @@ class TestSamplerCalculationBackends:
         """
         # Build circuit
         circuit = Circuit(4)
-        circuit.bs(0, loss=1 - db_loss_to_transmission(1))
-        circuit.bs(2, loss=1 - db_loss_to_transmission(2))
-        circuit.ps(1, 0.3, loss=1 - db_loss_to_transmission(0.5))
-        circuit.ps(3, 0.3, loss=1 - db_loss_to_transmission(0.5))
-        circuit.bs(1, loss=1 - db_loss_to_transmission(1))
-        circuit.bs(2, loss=1 - db_loss_to_transmission(2))
-        circuit.ps(1, 0.3, loss=1 - db_loss_to_transmission(0.5))
+        circuit.bs(0, loss=db_loss_to_decimal(1))
+        circuit.bs(2, loss=db_loss_to_decimal(2))
+        circuit.ps(1, 0.3, loss=db_loss_to_decimal(0.5))
+        circuit.ps(3, 0.3, loss=db_loss_to_decimal(0.5))
+        circuit.bs(1, loss=db_loss_to_decimal(1))
+        circuit.bs(2, loss=db_loss_to_decimal(2))
+        circuit.ps(1, 0.3, loss=db_loss_to_decimal(0.5))
         # Sample from circuit
         source = Source(purity=0.9, brightness=0.9, indistinguishability=0.9)
         sampler = Sampler(

--- a/tests/emulator/simulator_test.py
+++ b/tests/emulator/simulator_test.py
@@ -19,7 +19,7 @@ from lightworks import (
     Parameter,
     State,
     Unitary,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
     random_unitary,
 )
 from lightworks.emulator import ModeMismatchError, PhotonNumberError, Simulator
@@ -107,12 +107,12 @@ class TestSimulator:
         one input/output.
         """
         circ = Circuit(4)
-        circ.bs(0, loss=1 - db_loss_to_transmission(2))
+        circ.bs(0, loss=db_loss_to_decimal(2))
         circ.ps(1, phi=0.3)
-        circ.bs(1, loss=1 - db_loss_to_transmission(2))
-        circ.bs(2, loss=1 - db_loss_to_transmission(2))
+        circ.bs(1, loss=db_loss_to_decimal(2))
+        circ.bs(2, loss=db_loss_to_decimal(2))
         circ.ps(1, phi=0.5)
-        circ.bs(1, loss=1 - db_loss_to_transmission(2))
+        circ.bs(1, loss=db_loss_to_decimal(2))
         sim = Simulator(circ)
         results = sim.simulate(State([2, 0, 0, 0]), State([0, 1, 1, 0]))
         x = results.array[0, 0]

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -22,7 +22,7 @@ from lightworks import (
     Parameter,
     ParameterDict,
     Unitary,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
     random_unitary,
 )
 from lightworks.qubit import CNOT
@@ -60,7 +60,7 @@ class TestCircuit:
                 self.param_circuit.ps(j, self.parameters[f"ps_{i}_{j}"])
                 self.param_circuit.bs(j)
                 self.param_circuit.ps(j + 1, self.parameters[f"bs_{i}_{j}"])
-                self.param_circuit.bs(j, loss=1 - db_loss_to_transmission(0.1))
+                self.param_circuit.bs(j, loss=db_loss_to_decimal(0.1))
 
     def test_resultant_unitary(self):
         """
@@ -206,7 +206,7 @@ class TestCircuit:
         """Test combination of a circuit and unitary objects."""
         circ = Circuit(6)
         for i, m in enumerate([0, 2, 4, 1, 3, 2]):
-            circ.bs(m, loss=1 - db_loss_to_transmission(0.2))
+            circ.bs(m, loss=db_loss_to_decimal(0.2))
             circ.ps(m, i)
         u1 = Unitary(random_unitary(6, seed=1))
         u2 = Unitary(random_unitary(4, seed=2))
@@ -858,7 +858,7 @@ class TestCircuit:
         """
         p1 = Parameter(0.5)
         p2 = Parameter(2)
-        p3 = Parameter(1 - db_loss_to_transmission(3))
+        p3 = Parameter(db_loss_to_decimal(3))
         # Create circuit with parameters
         circuit = Circuit(4)
         circuit.bs(0, reflectivity=p1)
@@ -876,7 +876,7 @@ class TestCircuit:
         """
         p1 = Parameter(0.5)
         p2 = Parameter(2)
-        p3 = Parameter(1 - db_loss_to_transmission(3))
+        p3 = Parameter(db_loss_to_decimal(3))
         # Create sub-circuit with parameters
         sub_circuit = Circuit(4)
         sub_circuit.bs(0, reflectivity=p1)
@@ -966,8 +966,8 @@ class TestUnitary:
         u = Unitary(random_unitary(6, seed=95))
         circ = Circuit(4)
         circ.bs(0)
-        circ.bs(2, loss=1 - db_loss_to_transmission(0.5))
-        circ.bs(1, loss=1 - db_loss_to_transmission(0.2))
+        circ.bs(2, loss=db_loss_to_decimal(0.5))
+        circ.bs(1, loss=db_loss_to_decimal(0.2))
         u.add(circ, 1)
         assert u.U[0, 0] == pytest.approx(
             -0.27084817086493 - 0.176576418865914j, 1e-8

--- a/tests/sdk/display_test.py
+++ b/tests/sdk/display_test.py
@@ -25,7 +25,7 @@ from lightworks import (
     DisplayError,
     Parameter,
     Unitary,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
     random_unitary,
 )
 
@@ -42,9 +42,9 @@ class TestDisplay:
         for i, m in enumerate([0, 2, 1, 2, 0, 1]):
             self.circuit.bs(m)
             self.circuit.ps(m, phi=Parameter(i, label=f"p{i}"))
-            self.circuit.bs(m, loss=1 - db_loss_to_transmission(2))
+            self.circuit.bs(m, loss=db_loss_to_decimal(2))
             self.circuit.ps(m + 1, phi=3 * i)
-            self.circuit.loss(m, loss=1 - db_loss_to_transmission(1))
+            self.circuit.loss(m, loss=db_loss_to_decimal(1))
             self.circuit.loss(m, loss=Parameter(1, label="test"))
         self.circuit.bs(0, 3)
         self.circuit.bs(3, 0)

--- a/tests/sdk/util_test.py
+++ b/tests/sdk/util_test.py
@@ -21,10 +21,10 @@ from lightworks import (
     PostSelection,
     PostSelectionFunction,
     State,
-    db_loss_to_transmission,
+    db_loss_to_decimal,
+    decimal_to_db_loss,
     random_permutation,
     random_unitary,
-    transmission_to_db_loss,
 )
 from lightworks.sdk.utils import (
     add_heralds_to_state,
@@ -93,15 +93,15 @@ class TestUtils:
         assert abs(unitary[3, 2]) ** 2 == 1
 
     def test_db_loss_to_decimal_conv(self):
-        """Test conversion from db loss to a decimal transmission value."""
-        r = db_loss_to_transmission(0.5)
+        """Test conversion from db loss to a decimal loss value."""
+        r = 1 - db_loss_to_decimal(0.5)
         assert r == pytest.approx(0.8912509381337456, 1e-8)
 
     def test_decimal_to_db_loss_conv(self):
         """
-        Tests conversion between a decimal transmission and db loss value.
+        Tests conversion between a decimal loss and db loss value.
         """
-        r = transmission_to_db_loss(0.75)
+        r = decimal_to_db_loss(0.25)
         assert r == pytest.approx(1.2493873660829995, 1e-8)
 
     def test_seeded_random(self):


### PR DESCRIPTION
# Summary

The functions which allow for conversion to/from a db loss value have been updated to convert to a decimal loss rather than transmission. This improves compatibility with circuit loss elements and reduces the potential for mistakes when setting loss. 

## Full list of changes

- `db_loss_to_transmission` has been replaced with `db_loss_to_decimal`
- `transmission_to_db_loss` has been replaced with `decimal_to_db_loss`
- All dependant unit tests and docs have been updated.