### PR TITLE
Circuit copy bug fix

### DIFF
--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -77,7 +77,6 @@ class Circuit:
         self.__out_heralds: dict[int, int] = {}
         self.__external_in_heralds: dict[int, int] = {}
         self.__external_out_heralds: dict[int, int] = {}
-        self.__show_parameter_values = False
         self.__internal_modes: list[int] = []
 
         return
@@ -552,6 +551,7 @@ class Circuit:
         new_circ.__out_heralds = copy(self.__out_heralds)
         new_circ.__external_in_heralds = copy(self.__external_in_heralds)
         new_circ.__external_out_heralds = copy(self.__external_out_heralds)
+        new_circ.__internal_modes = copy(self.__internal_modes)
         return new_circ
 
     def unpack_groups(self) -> None:

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -281,6 +281,32 @@ class TestCircuit:
         # Unitary should not be modified
         assert (u_1 == u_2).all()
 
+    def test_circuit_copy_preserves_heralds(self):
+        """
+        Tests that circuit copy method is able to correctly copy over the
+        heralding data.
+        """
+        circ = CNOT()
+        circ.add(CNOT(), 0)
+        circ_copy = circ.copy()
+        # Check circuit has heralds and that they are identical
+        assert circ_copy.heralds
+        assert circ.heralds == circ_copy.heralds
+
+    def test_circuit_copy_preserves_internal_modes(self):
+        """
+        Tests that circuit copy method is able to correctly copy over the
+        internal mode data used for storing heralds.
+        """
+        circ = CNOT()
+        circ.add(CNOT(), 0)
+        circ_copy = circ.copy()
+        # Check circuit has internal modes and that they are preserved
+        assert circ_copy._Circuit__internal_modes
+        assert (
+            circ._Circuit__internal_modes == circ_copy._Circuit__internal_modes
+        )
+
     def test_circuit_ungroup(self):
         """
         Check that the unpack_groups method removes any grouped components from


### PR DESCRIPTION
# Summary

Fixes a bug in which the `__internal_modes` attribute used for managing modes was not duplicated between circuits. This created incorrect results in the resulting circuit. A unit test has also been added to check for this.
