### PR TITLE
Initial tomography routines

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,7 @@ Once setup, there is then a set of tutorials for familiarization with the module
    emulator_reference/index
    qubit_reference/index
    interferometers_reference/index
+   tomography_reference/index
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/tomography_reference/index.rst
+++ b/docs/source/tomography_reference/index.rst
@@ -1,0 +1,7 @@
+Tomography Reference
+====================
+
+.. toctree::
+    :maxdepth: 1
+
+    state_tomography

--- a/docs/source/tomography_reference/state_tomography.rst
+++ b/docs/source/tomography_reference/state_tomography.rst
@@ -1,0 +1,5 @@
+State Tomography
+================
+
+.. autoclass:: lightworks.tomography.StateTomography
+    :members:

--- a/lightworks/__init__.py
+++ b/lightworks/__init__.py
@@ -43,7 +43,7 @@ Key objects:
 
 """
 
-from . import emulator, interferometers, qubit
+from . import emulator, interferometers, qubit, tomography
 from .__version import __version__
 from .sdk.circuit import Circuit, Parameter, ParameterDict, Unitary
 from .sdk.optimisation import Optimisation
@@ -70,6 +70,6 @@ __all__ = [
     "Circuit", "Unitary", "Display", "State", "random_unitary",
     "random_permutation", "db_loss_to_decimal", "decimal_to_db_loss",
     "Parameter", "ParameterDict", "emulator", "qubit", "Optimisation",
-    "interferometers", "PostSelection", "PostSelectionFunction",
+    "interferometers", "PostSelection", "PostSelectionFunction", "tomography"
 ]
 # fmt: on

--- a/lightworks/emulator/simulation/quick_sampler.py
+++ b/lightworks/emulator/simulation/quick_sampler.py
@@ -176,7 +176,7 @@ class QuickSampler:
         """
         Function to sample a state from the provided distribution.
 
-        Returns
+        Returns:
 
             State : The sampled output state from the circuit.
 

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -210,7 +210,7 @@ class Sampler:
         """
         Function to sample a state from the provided distribution.
 
-        Returns
+        Returns:
 
             State : The sampled output state from the circuit.
 

--- a/lightworks/qubit/gates/three_qubit_gates.py
+++ b/lightworks/qubit/gates/three_qubit_gates.py
@@ -91,6 +91,6 @@ class CCNOT(Circuit):
 
         super().__init__(6)
 
-        controls = tuple([i for i in range(3) if i != target_qubit])
+        controls = tuple(i for i in range(3) if i != target_qubit)
         name = f"CCNOT ({controls}, {target_qubit})"
         self.add(circ, 0, group=True, name=name)

--- a/lightworks/sdk/circuit/parameters.py
+++ b/lightworks/sdk/circuit/parameters.py
@@ -222,7 +222,7 @@ class ParameterDict:
         Removes the parameter associated with the provided key from the
         ParameterDict.
 
-        Raises
+        Raises:
 
             KeyError : Raised in cases where the key to remove does not exit in
                 the ParameterDict.

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -164,7 +164,7 @@ class DrawCircuitSVG:
         """
         Draws the circuit as defined in the initial class class:
 
-        Returns
+        Returns:
 
             draw.Drawing : The created drawing with all circuit components.
 

--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Lightworks Tomography
+=====================
+
+A set of tools for quantum state & process tomography on a system.
+"""
+
+from .state_tomography import StateTomography

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -1,0 +1,185 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import FunctionType
+from typing import Callable
+
+import numpy as np
+
+from .. import qubit
+from ..sdk.circuit import Circuit
+from ..sdk.state import State
+
+Y_MEASUREMENT = Circuit(2)
+Y_MEASUREMENT.add(qubit.S())
+Y_MEASUREMENT.add(qubit.Z())
+Y_MEASUREMENT.add(qubit.H())
+
+MEASUREMENT_MAPPING = {
+    "I": qubit.I(),
+    "X": qubit.H(),
+    "Y": Y_MEASUREMENT,
+    "Z": qubit.I(),
+}
+PAULI_MAPPING = {
+    "I": np.array([[1, 0], [0, 1]]),
+    "X": np.array([[0, 1], [1, 0]]),
+    "Y": np.array([[0, -1j], [1j, 0]]),
+    "Z": np.array([[1, 0], [0, -1]]),
+}
+
+
+class StateTomography:
+    """
+    Generates the required circuit and performs data processing for the
+    calculation of the density matrix of a state.
+    """
+
+    def __init__(
+        self, n_qubits: int, base_circuit: Circuit, experiment: Callable
+    ) -> None:
+        if 2 * n_qubits != base_circuit.input_modes:
+            msg = (
+                "Number of circuit input modes does not match the amount "
+                "required for the specified number of qubits, expected "
+                f"{2 * n_qubits}."
+            )
+            raise ValueError(msg)
+
+        self._n_qubits = n_qubits
+        self._base_circuit = base_circuit
+        self._experiment = experiment
+
+    @property
+    def base_circuit(self) -> Circuit:
+        """
+        The base circuit which is to be modified as part of the tomography
+        calculations.
+        """
+        return self._base_circuit
+
+    @property
+    def n_qubits(self) -> int:
+        """
+        The number of qubits within the system.
+        """
+        return self._n_qubits
+
+    @property
+    def experiment(self) -> Callable:
+        """
+        A function to call which runs the required experiments. This should
+        accept a list of circuits as a single argument and then return a list
+        of the corresponding results, with each result being a dictionary or
+        Results object containing output states and counts.
+        """
+        return self._experiment
+
+    @experiment.setter
+    def experiment(self, value: Callable) -> None:
+        if not isinstance(value, FunctionType):
+            raise TypeError(
+                "Provided experiment should be a function which accepts a list "
+                "of circuits and returns a list of results containing only the "
+                "qubit modes."
+            )
+
+    def process(self) -> np.ndarray:
+        """
+        Performs the state tomography process with the configured elements to
+        calculate the density matrix of the output state.
+
+        Returns:
+
+            np.ndarray : The calculated density matrix from the state tomography
+                process.
+
+        """
+        # Find measurement combinations
+        combinations = list(MEASUREMENT_MAPPING.keys())
+        for _i in range(self.n_qubits - 1):
+            combinations = [
+                g1 + g2 for g1 in combinations for g2 in MEASUREMENT_MAPPING
+            ]
+
+        # Generate all circuits and run experiment
+        circuits = [
+            self._create_circuit(
+                [self._get_measurement_operator(g) for g in gates]
+            )
+            for gates in combinations
+        ]
+        all_results = self.experiment(circuits)
+
+        # Process results to find density matrix
+        rho = np.zeros((2**self.n_qubits, 2**self.n_qubits), dtype=complex)
+        for i, gates in enumerate([[*c] for c in combinations]):
+            results = all_results[i]
+            total = 0
+            n_counts = 0
+            for s, c in results.items():
+                n_counts += c
+                # Adjust multiplier to account for variation in eigenvalues
+                multiplier = 1
+                for j, gate in enumerate(gates):
+                    if gate == "I" or s[2 * j : 2 * j + 2] == State([1, 0]):
+                        multiplier *= 1
+                    elif s[2 * j : 2 * j + 2] == State([0, 1]):
+                        multiplier *= -1
+                total += multiplier * c
+            total /= (2**self.n_qubits) * n_counts
+            # Calculate tensor product of the operators used
+            mat = self._get_pauli_matrix(gates[0])
+            for g in gates[1:]:
+                mat = np.kron(mat, self._get_pauli_matrix(g))
+            # Updated density matrix
+            rho += total * mat
+
+        return rho
+
+    def _create_circuit(self, measurement_operators: list) -> Circuit:
+        """
+        Creates a copy of the assigned base circuit and applies the list of
+        measurement circuits to each pair of dual-rail encoded qubits.
+        """
+        circuit = self.base_circuit.copy()
+        # Check number of circuits is correct
+        if len(measurement_operators) != self.n_qubits:
+            msg = (
+                "Number of operators should match number of qubits "
+                f"({self.n_qubits})."
+            )
+            raise ValueError(msg)
+        # Add each and then return
+        for i, op in enumerate(measurement_operators):
+            circuit.add(op, 2 * i)
+
+        return circuit
+
+    def _get_measurement_operator(self, measurement: str) -> Circuit:
+        """
+        Returns the circuit required to transform between a measurement into the
+        Z basis.
+        """
+        if measurement not in MEASUREMENT_MAPPING:
+            raise ValueError("Provided measurement value not recognised.")
+        return MEASUREMENT_MAPPING[measurement]
+
+    def _get_pauli_matrix(self, measurement: str) -> np.ndarray:
+        """
+        Returns the pauli matrix associated with an observable.
+        """
+        if measurement not in PAULI_MAPPING:
+            raise ValueError("Provided measurement value not recognised.")
+        return PAULI_MAPPING[measurement]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = [
 line-length = 80
 indent-width = 4
 
-[tool.lint.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [tool.ruff.lint]
@@ -70,7 +70,6 @@ ignore = [
     "D205",
     "D212",
     "D400",
-    "D401",
     "D407",
     "D412",
     "D415",

--- a/tests/emulator/backend_test.py
+++ b/tests/emulator/backend_test.py
@@ -213,8 +213,8 @@ class TestSlos:
         """Check hom result and ensure returned value is as expected."""
         unitary = np.array([[1, 1j], [1j, 1]]) * 1 / (2**0.5)
         r = SLOS.calculate(unitary, State([1, 1]))
-        assert r[(1, 1)] == 0
-        assert r[(2, 0)] == pytest.approx(0.7071067811865475j)
+        assert r[1, 1] == 0
+        assert r[2, 0] == pytest.approx(0.7071067811865475j)
 
     def test_known_result(self):
         """
@@ -222,6 +222,6 @@ class TestSlos:
         """
         unitary = random_unitary(6, seed=23)
         r = SLOS.calculate(unitary, State([1, 0, 1, 0, 1, 0]))
-        assert r[(1, 1, 1, 0, 0, 0)] == pytest.approx(
+        assert r[1, 1, 1, 0, 0, 0] == pytest.approx(
             -0.0825807219472892 + 0.0727188703263498j
         )

--- a/tests/emulator/cnot_test.py
+++ b/tests/emulator/cnot_test.py
@@ -41,6 +41,7 @@ post_selection2.add((2, 3), 1)
 post_selects = [post_selection, post_selection2]
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize(
     ("backend", "post_selection"),
     [

--- a/tests/qubit/__init__.py
+++ b/tests/qubit/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/tomography/__init__.py
+++ b/tests/tomography/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -44,6 +44,7 @@ class TestStateTomography:
     Unit tests for state tomography class.
     """
 
+    @pytest.mark.flaky(max_runs=3)
     @pytest.mark.parametrize("n_qubits", [1, 2])
     def test_basic_state(self, n_qubits):
         """
@@ -58,6 +59,7 @@ class TestStateTomography:
         assert rho == pytest.approx(rho_exp, abs=1e-2)
         assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-3)
 
+    @pytest.mark.flaky(max_runs=3)
     @pytest.mark.parametrize("n_qubits", [1, 2])
     def test_ghz_state(self, n_qubits):
         """

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -56,7 +56,7 @@ class TestStateTomography:
         rho_exp = np.zeros((2**n_qubits, 2**n_qubits), dtype=complex)
         rho_exp[0, 0] = 1
         assert rho == pytest.approx(rho_exp, abs=1e-2)
-        assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-5)
+        assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-3)
 
     @pytest.mark.parametrize("n_qubits", [1, 2])
     def test_ghz_state(self, n_qubits):
@@ -76,7 +76,7 @@ class TestStateTomography:
         rho_exp[-1, 0] = 0.5
         rho_exp[-1, -1] = 0.5
         assert rho == pytest.approx(rho_exp, abs=1e-2)
-        assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-5)
+        assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-3)
 
     @pytest.mark.parametrize("n_modes", [2, 3, 5])
     def test_number_of_input_modes_twice_number_of_qubits(self, n_modes):

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -75,3 +75,20 @@ class TestStateTomography:
         rho_exp[-1, 0] = 0.5
         rho_exp[-1, -1] = 0.5
         assert rho == pytest.approx(rho_exp, abs=1e-2)
+
+    @pytest.mark.parametrize("n_modes", [2, 3, 5])
+    def test_number_of_input_modes_2_number_of_qubits(self, n_modes):
+        """
+        Checks that number of input modes must be twice number of qubits,
+        corresponding to dual rail encoding.
+        """
+        with pytest.raises(ValueError):
+            StateTomography(2, Circuit(n_modes))
+
+    @pytest.mark.parametrize("value", [Circuit(4), 4, None])
+    def test_experiment_must_be_function(self, value):
+        """
+        Checks value of experiment must be a function.
+        """
+        with pytest.raises(TypeError):
+            State(2, Circuit(4), value)

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from lightworks import Circuit, PostSelection, State, qubit
+from lightworks.emulator import Sampler
+from lightworks.tomography import StateTomography
+
+
+def experiment(circuits):
+    """
+    Experiment function for testing state tomography functionality is correct.
+    """
+    # Find number of qubits using available input modes.
+    n_qubits = int(circuits[0].input_modes / 2)
+    n_samples = 25000
+    post_selection = PostSelection()
+    for i in range(n_qubits):
+        post_selection.add((2 * i, 2 * i + 1), 1)
+    results = []
+    for circ in circuits:
+        sampler = Sampler(circ, State([1, 0] * n_qubits))
+        results.append(
+            sampler.sample_N_outputs(n_samples, post_select=post_selection)
+        )
+    return results
+
+
+class TestStateTomography:
+    """
+    Unit tests for state tomography class.
+    """
+
+    @pytest.mark.parametrize("n_qubits", [1, 2])
+    def test_basic_state(self, n_qubits):
+        """
+        Checks correct density matrix is produced when performing tomography on
+        the |0> X n_qubits state.
+        """
+        base_circ = Circuit(n_qubits * 2)
+        tomo = StateTomography(n_qubits, base_circ, experiment)
+        rho = tomo.process()
+        rho_exp = np.zeros((2**n_qubits, 2**n_qubits), dtype=complex)
+        rho_exp[0, 0] = 1
+        assert rho == pytest.approx(rho_exp, abs=1e-2)
+
+    @pytest.mark.parametrize("n_qubits", [1, 2])
+    def test_ghz_state(self, n_qubits):
+        """
+        Checks correct density matrix is produced when performing tomography on
+        the n_qubit GHZ state.
+        """
+        base_circ = Circuit(n_qubits * 2)
+        base_circ.add(qubit.H())
+        for i in range(n_qubits - 1):
+            base_circ.add(qubit.CNOT(), 2 * i)
+        tomo = StateTomography(n_qubits, base_circ, experiment)
+        rho = tomo.process()
+        rho_exp = np.zeros((2**n_qubits, 2**n_qubits), dtype=complex)
+        rho_exp[0, 0] = 0.5
+        rho_exp[0, -1] = 0.5
+        rho_exp[-1, 0] = 0.5
+        rho_exp[-1, -1] = 0.5
+        assert rho == pytest.approx(rho_exp, abs=1e-2)

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -56,6 +56,7 @@ class TestStateTomography:
         rho_exp = np.zeros((2**n_qubits, 2**n_qubits), dtype=complex)
         rho_exp[0, 0] = 1
         assert rho == pytest.approx(rho_exp, abs=1e-2)
+        assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-5)
 
     @pytest.mark.parametrize("n_qubits", [1, 2])
     def test_ghz_state(self, n_qubits):
@@ -75,6 +76,7 @@ class TestStateTomography:
         rho_exp[-1, 0] = 0.5
         rho_exp[-1, -1] = 0.5
         assert rho == pytest.approx(rho_exp, abs=1e-2)
+        assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-5)
 
     @pytest.mark.parametrize("n_modes", [2, 3, 5])
     def test_number_of_input_modes_twice_number_of_qubits(self, n_modes):
@@ -92,3 +94,11 @@ class TestStateTomography:
         """
         with pytest.raises(TypeError):
             State(2, Circuit(4), value)
+
+    def test_density_mat_before_calc(self):
+        """
+        Checks an error is raised
+        """
+        tomo = StateTomography(2, Circuit(4), experiment)
+        with pytest.raises(AttributeError):
+            tomo.rho  # noqa: B018

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -77,13 +77,13 @@ class TestStateTomography:
         assert rho == pytest.approx(rho_exp, abs=1e-2)
 
     @pytest.mark.parametrize("n_modes", [2, 3, 5])
-    def test_number_of_input_modes_2_number_of_qubits(self, n_modes):
+    def test_number_of_input_modes_twice_number_of_qubits(self, n_modes):
         """
         Checks that number of input modes must be twice number of qubits,
         corresponding to dual rail encoding.
         """
         with pytest.raises(ValueError):
-            StateTomography(2, Circuit(n_modes))
+            StateTomography(2, Circuit(n_modes), experiment)
 
     @pytest.mark.parametrize("value", [Circuit(4), 4, None])
     def test_experiment_must_be_function(self, value):


### PR DESCRIPTION
# Summary

Adds the Tomography module, which for now includes a routine for performing state tomography, but will be expanded to included process tomography as well. Unit tests and associated docs have also been included.