### PR TITLE
Change branching strategy to github flow

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: 
       - main
-      - release-*
 
   # Allows workflow to be manually run from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches:
       - main
-      - release-*
 
   # Allows workflow to be manually run from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/sphinx_deploy.yml
+++ b/.github/workflows/sphinx_deploy.yml
@@ -4,7 +4,8 @@ name: Deploy Docs
 on:
   # Triggers the workflow on push events for main
   push:
-    branches: [main]
+    branches:
+      - main
 
   # Allows workflow to be manually run from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test
 
 on:
   push:
@@ -7,13 +7,12 @@ on:
   pull_request:
     branches: 
       - main
-      - release-*
 
   # Allows workflow to be manually run from the Actions tab
   workflow_dispatch:
         
 jobs:
-  test:
+  pytest:
 
     runs-on: ubuntu-latest
     strategy:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,7 +1,7 @@
 Contributing
 ============
 
-To contribute to Lightworks, please fork the repo and then merge changes back via a pull request, in the first instance the target for this should be the main branch. Before opening the pull request, all unit tests should be run using `pytest <https://pytest.org/>`_ and these should all pass unless there is good justification otherwise (e.g. the new feature changes core functionality). Additionally, unit tests should be written for all new features to ensure correct functionality of these.
+To contribute to Lightworks, please fork the repo and then merge changes back via a pull request to the main branch. Before opening the pull request, all unit tests should be run using `pytest <https://pytest.org/>`_ and these should all pass unless there is good justification otherwise (e.g. the new feature changes core functionality). Additionally, unit tests should be written for all new features to ensure correct functionality of these.
 
 Code Style
 ----------


### PR DESCRIPTION
# Summary

Moving forward, Lightworks will use the GitHub flow branching strategy to allow for more continual updates to the main branch. This PR modifies the workflows and contributing section of the docs to reflect this change.