### PR TITLE
Support for additional args within StateTomography experiment function

### DIFF
--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -20,3 +20,4 @@ A set of tools for quantum state & process tomography on a system.
 """
 
 from .state_tomography import StateTomography
+from .utils import state_fidelity

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -192,8 +192,8 @@ class StateTomography:
             rho += total * mat
 
         # Assign to attribute then return
-        self._rho = rho
-        return self._rho
+        self._rho: np.ndarray = rho
+        return self.rho
 
     def fidelity(self, rho_exp: np.ndarray) -> float:
         """
@@ -210,7 +210,7 @@ class StateTomography:
 
         """
         rho_exp = np.array(rho_exp)
-        rho_root = sqrtm(self._rho)
+        rho_root = sqrtm(self.rho)
         inner = rho_root @ rho_exp @ rho_root
         return abs(np.trace(sqrtm(inner)))
 

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -61,10 +61,17 @@ class StateTomography:
             tomography experiments. This should accept a list of circuits and
             return a list of results to process.
 
+        experiment_args (list | None) : Optionally provide additional arguments
+            which will be passed directly to the experiment function.
+
     """
 
     def __init__(
-        self, n_qubits: int, base_circuit: Circuit, experiment: Callable
+        self,
+        n_qubits: int,
+        base_circuit: Circuit,
+        experiment: Callable,
+        experiment_args: list | None = None,
     ) -> None:
         # Type check inputs
         if not isinstance(n_qubits, int) or isinstance(n_qubits, bool):
@@ -83,6 +90,7 @@ class StateTomography:
         self._n_qubits = n_qubits
         self._base_circuit = base_circuit
         self.experiment = experiment
+        self.experiment_args = experiment_args
 
     @property
     def base_circuit(self) -> Circuit:
@@ -156,7 +164,8 @@ class StateTomography:
             )
             for gates in combinations
         ]
-        all_results = self.experiment(circuits)
+        args = self.experiment_args if self.experiment_args is not None else []
+        all_results = self.experiment(circuits, *args)
 
         # Process results to find density matrix
         rho = np.zeros((2**self.n_qubits, 2**self.n_qubits), dtype=complex)

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -16,11 +16,11 @@ from types import FunctionType
 from typing import Callable
 
 import numpy as np
-from scipy.linalg import sqrtm
 
 from .. import qubit
 from ..sdk.circuit import Circuit
 from ..sdk.state import State
+from .utils import state_fidelity
 
 _y_measure = Circuit(2)
 _y_measure.add(qubit.S())
@@ -197,8 +197,8 @@ class StateTomography:
 
     def fidelity(self, rho_exp: np.ndarray) -> float:
         """
-        Calculates the fidelity of the quantum state against the expected
-        density matrix for the state.
+        Calculates the fidelity of the calculated quantum state against the
+        expected density matrix for the state.
 
         Args:
 
@@ -209,10 +209,7 @@ class StateTomography:
             float : The calculated fidelity value.
 
         """
-        rho_exp = np.array(rho_exp)
-        rho_root = sqrtm(self.rho)
-        inner = rho_root @ rho_exp @ rho_root
-        return abs(np.trace(sqrtm(inner)))
+        return state_fidelity(self.rho, rho_exp)
 
     def _create_circuit(self, measurement_operators: list) -> Circuit:
         """

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from scipy.linalg import sqrtm
+
+
+def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
+    """
+    Calculates the fidelity of the density matrix for a quantum state against
+    the expected density matrix.
+
+    Args:
+
+        rho (np.ndarray) : The density matrix of the quantum state.
+
+        rho_exp (np.ndarray) : The expected density matrix.
+
+    Returns:
+
+        float : The calculated fidelity value.
+
+    """
+    rho_exp = np.array(rho_exp)
+    rho_root = sqrtm(np.array(rho))
+    if rho_exp.shape != rho_root.shape:
+        msg = (
+            "Mismatch in dimensions between provided density matrices, "
+            f"{rho_root.shape} & {rho_root.shape}."
+        )
+        raise ValueError(msg)
+    inner = rho_root @ rho_exp @ rho_root
+    return abs(np.trace(sqrtm(inner)))

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -47,6 +47,13 @@ def experiment(circuits):
     return results
 
 
+def experiment_args(circuits, arg1, arg2):  # noqa: ARG001
+    """
+    For testing ability to provided arguments to an experiment.
+    """
+    return experiment(circuits)
+
+
 class TestStateTomography:
     """
     Unit tests for state tomography class.
@@ -172,3 +179,12 @@ class TestStateTomography:
         tomo = StateTomography(2, Circuit(4), experiment)
         with pytest.raises(ValueError):
             tomo._create_circuit("XYZ")
+
+    def test_experiment_args(self):
+        """
+        Checks that experiment arguments can be provided to StateTomography.
+        """
+        tomo = StateTomography(
+            2, Circuit(4), experiment_args, experiment_args=[1, 2]
+        )
+        tomo.process()

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -28,9 +28,9 @@ from lightworks.tomography import StateTomography
 from lightworks.tomography.state_tomography import MEASUREMENT_MAPPING
 
 
-def experiment(circuits):
+def experiment_args(circuits, input_state):
     """
-    Experiment function for testing state tomography functionality is correct.
+    Experiment function with ability to specify the input state used.
     """
     # Find number of qubits using available input modes.
     n_qubits = int(circuits[0].input_modes / 2)
@@ -40,18 +40,19 @@ def experiment(circuits):
         post_selection.add((2 * i, 2 * i + 1), 1)
     results = []
     for circ in circuits:
-        sampler = Sampler(circ, State([1, 0] * n_qubits), backend="slos")
+        sampler = Sampler(circ, input_state, backend="slos")
         results.append(
             sampler.sample_N_outputs(n_samples, post_select=post_selection)
         )
     return results
 
 
-def experiment_args(circuits, arg1, arg2):  # noqa: ARG001
+def experiment(circuits):
     """
-    For testing ability to provided arguments to an experiment.
+    Experiment function for testing state tomography functionality is correct.
     """
-    return experiment(circuits)
+    n_qubits = int(circuits[0].input_modes / 2)
+    return experiment_args(circuits, State([1, 0] * n_qubits))
 
 
 class TestStateTomography:
@@ -130,11 +131,21 @@ class TestStateTomography:
 
     def test_density_mat_before_calc(self):
         """
-        Checks an error is raised
+        Checks an error is raised if the rho attribute is called before
+        tomography is performed.
         """
         tomo = StateTomography(2, Circuit(4), experiment)
         with pytest.raises(AttributeError):
             tomo.rho  # noqa: B018
+
+    def test_fidleity_before_calc(self):
+        """
+        Checks an error is raised if a user attempts to calculate fidelity
+        before performing tomography.
+        """
+        tomo = StateTomography(2, Circuit(4), experiment)
+        with pytest.raises(AttributeError):
+            tomo.fidelity(np.identity(2))
 
     def test_base_circuit_unmodified(self):
         """
@@ -185,6 +196,10 @@ class TestStateTomography:
         Checks that experiment arguments can be provided to StateTomography.
         """
         tomo = StateTomography(
-            2, Circuit(4), experiment_args, experiment_args=[1, 2]
+            1, Circuit(2), experiment_args, experiment_args=[State([1, 0])]
         )
-        tomo.process()
+        rho = tomo.process()
+        rho_exp = np.zeros((2, 2), dtype=complex)
+        rho_exp[0, 0] = 1
+        assert rho == pytest.approx(rho_exp, abs=1e-2)
+        assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-3)

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from lightworks import random_unitary
+from lightworks.tomography import state_fidelity
+
+
+class TestUtils:
+    """
+    Unit tests for utilities of the tomography module.
+    """
+
+    @pytest.mark.parametrize(
+        "rho",
+        [
+            [[1, 0], [0, 0]],
+            [[0.5, 0.5], [0.5, 0.5]],
+            [[0.5, 0.5j], [-0.5j, 0.5]],
+        ],
+    )
+    def test_state_fidelity(self, rho):
+        """
+        Validate that fidelity value is always 1 when using two identical
+        matrices.
+        """
+        rho = np.array(rho)
+        assert state_fidelity(rho, rho) == pytest.approx(1, 1e-6)
+
+    def test_state_fidelity_dim_mismatch(self):
+        """
+        Check an error is raised if there is a mismatch in dimensions between
+        density matrices.
+        """
+        with pytest.raises(ValueError, match="dimensions"):
+            state_fidelity(random_unitary(3), random_unitary(4))


### PR DESCRIPTION
# Summary

Closes #87, allowing provision of additional arguments which are passed directly to the experiment function of StateTomography through the experimental_args attribute. No validation is performed on this attribute.

The fidelity calculation has also been moved into a dedicated `state_fidelity` function which is then called by StateTomography. This new function can be called directly from the main tomography import.
