### PR TITLE
State tomography measurement optimisation

### DIFF
--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -157,20 +157,25 @@ class StateTomography:
                 g1 + g2 for g1 in combinations for g2 in MEASUREMENT_MAPPING
             ]
 
+        result_mapping = {c: c.replace("I", "Z") for c in combinations}
+        measurements = list(set(result_mapping.values()))
+
         # Generate all circuits and run experiment
         circuits = [
             self._create_circuit(
                 [self._get_measurement_operator(g) for g in gates]
             )
-            for gates in combinations
+            for gates in measurements
         ]
         args = self.experiment_args if self.experiment_args is not None else []
         all_results = self.experiment(circuits, *args)
+        results_dict = dict(zip(measurements, all_results))
 
         # Process results to find density matrix
         rho = np.zeros((2**self.n_qubits, 2**self.n_qubits), dtype=complex)
-        for i, gates in enumerate([[*c] for c in combinations]):
-            results = all_results[i]
+        for comb in combinations:
+            gates = [*comb]
+            results = results_dict[result_mapping[comb]]
             total = 0
             n_counts = 0
             for s, c in results.items():

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -42,7 +42,9 @@ def experiment_args(circuits, input_state):
     for circ in circuits:
         sampler = Sampler(circ, input_state, backend="slos")
         results.append(
-            sampler.sample_N_outputs(n_samples, post_select=post_selection)
+            sampler.sample_N_outputs(
+                n_samples, post_select=post_selection, seed=29
+            )
         )
     return results
 
@@ -60,7 +62,6 @@ class TestStateTomography:
     Unit tests for state tomography class.
     """
 
-    @pytest.mark.flaky(max_runs=3)
     @pytest.mark.parametrize("n_qubits", [1, 2])
     def test_basic_state(self, n_qubits):
         """
@@ -75,7 +76,6 @@ class TestStateTomography:
         assert rho == pytest.approx(rho_exp, abs=1e-2)
         assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-3)
 
-    @pytest.mark.flaky(max_runs=3)
     @pytest.mark.parametrize("n_qubits", [1, 2])
     def test_ghz_state(self, n_qubits):
         """

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -62,7 +62,7 @@ class TestStateTomography:
     Unit tests for state tomography class.
     """
 
-    @pytest.mark.parametrize("n_qubits", [1, 2])
+    @pytest.mark.parametrize("n_qubits", [1, 2, 3])
     def test_basic_state(self, n_qubits):
         """
         Checks correct density matrix is produced when performing tomography on
@@ -76,7 +76,7 @@ class TestStateTomography:
         assert rho == pytest.approx(rho_exp, abs=1e-2)
         assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-3)
 
-    @pytest.mark.parametrize("n_qubits", [1, 2])
+    @pytest.mark.parametrize("n_qubits", [1, 2, 3])
     def test_ghz_state(self, n_qubits):
         """
         Checks correct density matrix is produced when performing tomography on


### PR DESCRIPTION
# Summary

Enhances `StateTomography` routine by reusing data for any measurements taken in the `I` basis. In this basis the expectation value is always 1, so it is possible to omit these from measurement and instead use data from another operator. In this case `Z` is chosen, meaning for the two qubit case `II` uses the `ZZ` data or `IX` would use the `ZX` data. This reduces the total number of measurements required from 4^n to 3^n.
