### PR TITLE
Process tomography

### DIFF
--- a/docs/source/tomography_reference/index.rst
+++ b/docs/source/tomography_reference/index.rst
@@ -5,3 +5,5 @@ Tomography Reference
     :maxdepth: 1
 
     state_tomography
+    process_tomography
+    utils

--- a/docs/source/tomography_reference/process_tomography.rst
+++ b/docs/source/tomography_reference/process_tomography.rst
@@ -1,0 +1,5 @@
+Process Tomography
+==================
+
+.. autoclass:: lightworks.tomography.ProcessTomography
+    :members:

--- a/docs/source/tomography_reference/utils.rst
+++ b/docs/source/tomography_reference/utils.rst
@@ -1,0 +1,5 @@
+Utilities
+=========
+
+.. automodule:: lightworks.tomography.utils
+    :members:

--- a/lightworks/sdk/circuit/circuit.py
+++ b/lightworks/sdk/circuit/circuit.py
@@ -426,7 +426,7 @@ class Circuit:
         swaps = {
             self._map_mode(mi): self._map_mode(mo) for mi, mo in swaps.items()
         }
-        for m in list(swaps.keys()) + list(swaps.values()):
+        for m in [*swaps.keys(), *swaps.values()]:
             self._mode_in_range(m)
         self.__circuit_spec.append(ModeSwaps(swaps))
 

--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -21,4 +21,18 @@ A set of tools for quantum state & process tomography on a system.
 
 from .process_tomography import ProcessTomography
 from .state_tomography import StateTomography
-from .utils import density_from_state, process_fidelity, state_fidelity
+from .utils import (
+    choi_from_unitary,
+    density_from_state,
+    process_fidelity,
+    state_fidelity,
+)
+
+__all__ = [
+    "ProcessTomography",
+    "StateTomography",
+    "choi_from_unitary",
+    "density_from_state",
+    "process_fidelity",
+    "state_fidelity",
+]

--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -19,5 +19,6 @@ Lightworks Tomography
 A set of tools for quantum state & process tomography on a system.
 """
 
+from .process_tomography import ProcessTomography
 from .state_tomography import StateTomography
 from .utils import state_fidelity

--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -21,4 +21,4 @@ A set of tools for quantum state & process tomography on a system.
 
 from .process_tomography import ProcessTomography
 from .state_tomography import StateTomography
-from .utils import state_fidelity
+from .utils import process_fidelity, state_fidelity

--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -21,4 +21,4 @@ A set of tools for quantum state & process tomography on a system.
 
 from .process_tomography import ProcessTomography
 from .state_tomography import StateTomography
-from .utils import process_fidelity, state_fidelity
+from .utils import density_from_state, process_fidelity, state_fidelity

--- a/lightworks/tomography/process_tomography.py
+++ b/lightworks/tomography/process_tomography.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable
+
+import numpy as np
+
+from .. import qubit
+from ..sdk.circuit import Circuit
+from ..sdk.state import State
+from .state_tomography import StateTomography as StateTomo
+
+TOMO_INPUTS = ["0", "1", "+", "R"]
+
+r_transform = qubit.H()
+r_transform.add(qubit.S())
+
+INPUT_MAPPING: dict[str, tuple[State, Circuit]] = {
+    "0": (State([1, 0]), qubit.I()),
+    "1": (State([0, 1]), qubit.I()),
+    "+": (State([1, 0]), qubit.H()),
+    "R": (State([1, 0]), r_transform),
+}
+
+
+class ProcessTomography:
+    """
+    Desc
+    """
+
+    def __init__(
+        self,
+        n_qubits: int,
+        base_circuit: Circuit,
+        experiment: Callable,
+        experiment_args: list | None = None,
+    ) -> None:
+        self.n_qubits = n_qubits
+        self.base_circuit = base_circuit
+        self.experiment = experiment
+        self.experiment_args = experiment_args
+
+    def process(self) -> np.ndarray:
+        """
+        Desc
+        """
+        all_inputs = list(TOMO_INPUTS)
+        for _ in range(self.n_qubits - 1):
+            all_inputs = [i1 + i2 for i1 in all_inputs for i2 in TOMO_INPUTS]
+
+        req_measurements, result_mapping = StateTomo._get_required_measurements(
+            self.n_qubits
+        )
+
+        all_circuits = []
+        all_input_states = []
+
+        for in_state in all_inputs:
+            for meas in req_measurements:
+                circ, state = self._create_circuit_and_input(in_state, meas)
+                all_circuits.append(circ)
+                all_input_states.append(state)
+
+        experiment_args = (
+            self.experiment_args if self.experiment_args is not None else []
+        )
+
+        results = self.experiment(
+            all_circuits, all_input_states, *experiment_args
+        )
+
+        # Sorted results into each input/measurement combination
+        n_per_in = len(req_measurements)
+        sorted_results = {
+            in_state: dict(
+                zip(
+                    req_measurements, results[n_per_in * i : n_per_in * (i + 1)]
+                )
+            )
+            for i, in_state in enumerate(all_inputs)
+        }
+        # Expand results to include all of the required measurements
+        full_results = {}
+        for in_state, res in sorted_results.items():
+            full_res = {
+                meas: res[result_mapping[meas]]
+                for meas in StateTomo._get_all_measurements(self.n_qubits)
+            }
+            full_results[in_state] = full_res
+
+        return {
+            in_state: StateTomo._calculate_density_matrix(self.n_qubits, res)
+            for in_state, res in full_results.items()
+        }
+
+    def _create_circuit_and_input(
+        self, input_op: str, output_op: str
+    ) -> tuple[Circuit, State]:
+        """
+        Desc
+        """
+        in_state = State([])
+        circ = Circuit(self.base_circuit.input_modes)
+
+        for i, op in enumerate(input_op):
+            in_state += INPUT_MAPPING[op][0]
+            circ.add(INPUT_MAPPING[op][1], 2 * i)
+
+        circ.add(self.base_circuit)
+
+        for i, op in enumerate(output_op):
+            circ.add(StateTomo._get_measurement_operator(op), 2 * i)
+
+        return circ, in_state

--- a/lightworks/tomography/process_tomography.py
+++ b/lightworks/tomography/process_tomography.py
@@ -20,6 +20,7 @@ from .. import qubit
 from ..sdk.circuit import Circuit
 from ..sdk.state import State
 from .state_tomography import StateTomography as StateTomo
+from .utils import process_fidelity
 
 TOMO_INPUTS = ["0", "1", "+", "R"]
 
@@ -51,6 +52,16 @@ class ProcessTomography:
         self.experiment = experiment
         self.experiment_args = experiment_args
 
+    @property
+    def chi(self) -> np.ndarray:
+        """Returns the calculate chi matrix for a circuit."""
+        if not hasattr(self, "_chi"):
+            raise AttributeError(
+                "Chi has not yet been calculated, this can be achieved with the"
+                "process method."
+            )
+        return self._chi
+
     def process(self) -> dict[str, np.ndarray]:
         """
         Desc
@@ -62,6 +73,13 @@ class ProcessTomography:
         results = self._run_required_experiments(all_inputs)
 
         return self._calculate_density_matrices(results)
+
+    def fidelity(self, chi_exp: np.ndarray) -> float:
+        """
+        Calculates fidelity of the calculated chi matrix compared to the
+        expected one.
+        """
+        return process_fidelity(self.chi, chi_exp)
 
     def _run_required_experiments(
         self, inputs: list[str]

--- a/lightworks/tomography/process_tomography.py
+++ b/lightworks/tomography/process_tomography.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import FunctionType
 from typing import Callable
 
 import numpy as np
@@ -20,7 +21,7 @@ from .. import qubit
 from ..sdk.circuit import Circuit
 from ..sdk.state import State
 from .state_tomography import StateTomography as StateTomo
-from .utils import process_fidelity
+from .utils import PAULI_MAPPING, process_fidelity
 
 TOMO_INPUTS = ["0", "1", "+", "R"]
 
@@ -33,17 +34,36 @@ INPUT_MAPPING: dict[str, tuple[State, Circuit]] = {
     "+": (State([1, 0]), qubit.H()),
     "R": (State([1, 0]), r_transform),
 }
-BASIS_MAPPING: dict[str, list] = {
-    "0": [1, 0],
-    "1": [0, 1],
-    "+": [2**-0.5, 2**-0.5],
-    "R": [2**-0.5, 1j * 2**-0.5],
+RHOS_MAPPING: dict[str, np.ndarray] = {
+    "0": np.array([[1, 0], [0, 0]]),
+    "1": np.array([[0, 0], [0, 1]]),
+    "+": np.array([[0.5, 0.5], [0.5, 0.5]]),
+    "R": np.array([[0.5, -0.5j], [0.5j, 0.5]]),
 }
 
 
 class ProcessTomography:
     """
-    Desc
+    Generates the required configurations for the calculation of the choi matrix
+    representation of a process.
+
+    Args:
+
+        n_qubits (int) : The number of qubits that will be used as part of the
+            tomography.
+
+        base_circuit (Circuit) : An initial circuit which produces the required
+            output state and can be modified for performing tomography. It is
+            required that the number of circuit input modes equals 2 * the
+            number of qubits.
+
+        experiment (Callable) : A function for performing the required
+            tomography experiments. This should accept a list of circuits and a
+            list of inputs and then return a list of results to process.
+
+        experiment_args (list | None) : Optionally provide additional arguments
+            which will be passed directly to the experiment function.
+
     """
 
     def __init__(
@@ -53,83 +73,132 @@ class ProcessTomography:
         experiment: Callable,
         experiment_args: list | None = None,
     ) -> None:
-        self.n_qubits = n_qubits
-        self.base_circuit = base_circuit
+        # Type check inputs
+        if not isinstance(n_qubits, int) or isinstance(n_qubits, bool):
+            raise TypeError("Number of qubits should be an integer.")
+        if not isinstance(base_circuit, Circuit):
+            raise TypeError("Base circuit should be a circuit object.")
+
+        if 2 * n_qubits != base_circuit.input_modes:
+            msg = (
+                "Number of circuit input modes does not match the amount "
+                "required for the specified number of qubits, expected "
+                f"{2 * n_qubits}."
+            )
+            raise ValueError(msg)
+
+        self._n_qubits = n_qubits
+        self._base_circuit = base_circuit
         self.experiment = experiment
         self.experiment_args = experiment_args
+        self._choi: np.ndarray
 
     @property
-    def chi(self) -> np.ndarray:
-        """Returns the calculate chi matrix for a circuit."""
-        if not hasattr(self, "_chi"):
+    def base_circuit(self) -> Circuit:
+        """
+        The base circuit which is to be modified as part of the tomography
+        calculations.
+        """
+        return self._base_circuit
+
+    @property
+    def n_qubits(self) -> int:
+        """
+        The number of qubits within the system.
+        """
+        return self._n_qubits
+
+    @property
+    def experiment(self) -> Callable:
+        """
+        A function to call which runs the required experiments. This should
+        accept a list of circuits as a single argument and then return a list
+        of the corresponding results, with each result being a dictionary or
+        Results object containing output states and counts.
+        """
+        return self._experiment
+
+    @experiment.setter
+    def experiment(self, value: Callable) -> None:
+        if not isinstance(value, FunctionType):
+            raise TypeError(
+                "Provided experiment should be a function which accepts a list "
+                "of circuits and returns a list of results containing only the "
+                "qubit modes."
+            )
+        self._experiment = value
+
+    @property
+    def choi(self) -> np.ndarray:
+        """Returns the calculate choi matrix for a circuit."""
+        if not hasattr(self, "_choi"):
             raise AttributeError(
                 "Chi has not yet been calculated, this can be achieved with the"
                 "process method."
             )
-        return self._chi
+        return self._choi
 
     def process(self) -> np.ndarray:
         """
-        Desc
+        Performs process tomography with the configured elements and calculates
+        the choi matrix using linear inversion.
+
+        Returns:
+
+            np.ndarray : The calculated choi matrix for the process.
+
         """
         all_inputs = list(TOMO_INPUTS)
         for _ in range(self.n_qubits - 1):
             all_inputs = [i1 + i2 for i1 in all_inputs for i2 in TOMO_INPUTS]
-
         results = self._run_required_experiments(all_inputs)
-
-        rhos_full = self._calculate_density_matrices(results)
-        rhos = [rhos_full[in_s] for in_s in all_inputs]
-
-        transform = self._calculate_transform_matrix(self.n_qubits, all_inputs)
-
-        rhos_t = [
-            sum(transform[i][j] * rhos[j] for j in range(len(rhos)))
-            for i in range(len(rhos))
-        ]
-        full_mat = np.zeros(
-            (2 ** (2 * self.n_qubits), 2 ** (2 * self.n_qubits)), dtype=complex
-        )
-
-        for i in range(2**self.n_qubits):
-            for j in range(2**self.n_qubits):
-                mat = rhos_t[2**self.n_qubits * i + j]
-                full_mat[
-                    2**self.n_qubits * i : 2**self.n_qubits * (i + 1),
-                    2**self.n_qubits * j : 2**self.n_qubits * (j + 1),
-                ] = mat[:, :]
-
-        x_mat = np.array([[0, 1], [1, 0]])
-        a_mat = 0.5 * (
-            np.kron(np.array([[1, 0], [0, -1]]), np.identity(2))
-            + np.kron(x_mat, x_mat)
-        )
-        if self.n_qubits == 1:
-            k_mat = a_mat
-        elif self.n_qubits == 2:
-            m_mat = np.array(
-                [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]
+        # Get expectation values using results
+        lambdas = {
+            (in_state, measurement): StateTomo._calculate_expectation_value(
+                measurement, res
             )
-            a2_mat = np.kron(a_mat, a_mat)
-            p_mat = np.kron(np.identity(2), np.kron(m_mat, np.identity(2)))
-            k_mat = p_mat @ a2_mat
-        else:
-            raise NotImplementedError("Not yet generalized.")
+            for (in_state, measurement), res in results.items()
+        }
+        # Find all pauli and density matrices for multi-qubit states
+        full_paulis = dict(PAULI_MAPPING)
+        full_rhos = dict(RHOS_MAPPING)
+        for _ in range(self.n_qubits - 1):
+            full_paulis = {
+                k1 + k2: np.kron(v1, v2)
+                for k1, v1 in full_paulis.items()
+                for k2, v2 in PAULI_MAPPING.items()
+            }
+            full_rhos = {
+                k1 + k2: np.kron(v1, v2)
+                for k1, v1 in full_rhos.items()
+                for k2, v2 in RHOS_MAPPING.items()
+            }
+        # Determine the transformation matrix to perform linear inversion
+        dim = 2**self.n_qubits
+        transform_matrix = np.zeros((dim**4, dim**4), dtype=complex)
+        for i, (in_s, meas) in enumerate(lambdas):
+            transform_matrix[i, :] = (
+                np.kron(np.array(full_rhos[in_s]).conj(), full_paulis[meas])
+                .flatten()
+                .conj()
+            )
+        # Then find the choi matrix
+        choi = np.linalg.pinv(transform_matrix) @ np.array(
+            list(lambdas.values())
+        )
+        self._choi = choi.reshape(dim**2, dim**2)
+        return self.choi
 
-        self._chi = k_mat.T @ full_mat @ k_mat
-
-        return self.chi
-
-    def fidelity(self, chi_exp: np.ndarray) -> float:
+    def fidelity(self, choi_exp: np.ndarray) -> float:
         """
-        Calculates fidelity of the calculated chi matrix compared to the
+        Calculates fidelity of the calculated choi matrix compared to the
         expected one.
         """
-        return process_fidelity(self.chi, chi_exp)
+        return process_fidelity(self.choi, choi_exp)
 
     def _run_required_experiments(
         self, inputs: list[str]
-    ) -> dict[str, dict[str, dict]]:
+    ) -> dict[tuple[str, str], dict[str, int]]:
         """
         Runs all required experiments to find density matrices for a provided
         set of inputs.
@@ -165,68 +234,26 @@ class ProcessTomography:
         # Expand results to include all of the required measurements
         full_results = {}
         for in_state, res in sorted_results.items():
-            full_res = {
-                meas: res[result_mapping[meas]]
-                for meas in StateTomo._get_all_measurements(self.n_qubits)
-            }
-            full_results[in_state] = full_res
+            for meas in StateTomo._get_all_measurements(self.n_qubits):
+                full_results[in_state, meas] = res[result_mapping[meas]]
         return full_results
-
-    def _calculate_density_matrices(
-        self, results: dict[str, dict[str, dict]]
-    ) -> dict[str, np.ndarray]:
-        """
-        Calculates density matrices for each input and set of results in the
-        provided dictionary.
-        """
-        return {
-            in_state: StateTomo._calculate_density_matrix(self.n_qubits, res)
-            for in_state, res in results.items()
-        }
-
-    def _calculate_transform_matrix(
-        self, n_qubits: int, inputs: list[str]
-    ) -> np.ndarray:
-        """
-        Calculates the matrix required to transform between input basis and
-        pauli basis.
-        """
-        basis = []
-        for in_state in inputs:
-            in_vector = np.array(BASIS_MAPPING[in_state[0]], dtype=complex)
-            for i in range(n_qubits - 1):
-                in_vector = np.kron(in_vector, BASIS_MAPPING[in_state[i + 1]])
-            basis.append(np.outer(in_vector, np.conj(in_vector.T)))
-        basis_vectors = np.column_stack([m.flatten() for m in basis])
-
-        transform = np.zeros(
-            (2 ** (2 * n_qubits), 2 ** (2 * n_qubits)), dtype=complex
-        )
-        for i in range(len(inputs)):
-            target_rho = np.zeros((2**n_qubits, 2**n_qubits), dtype=complex)
-            target_rho[int(i / 2**n_qubits), i % (2**n_qubits)] = 1
-
-            mu = np.linalg.solve(basis_vectors, target_rho.flatten())
-            transform[i, :] = mu[:]
-
-        return transform
 
     def _create_circuit_and_input(
         self, input_op: str, output_op: str
     ) -> tuple[Circuit, State]:
         """
-        Desc
+        Creates the required circuit and input state to achieve a provided input
+        and output operation.
         """
         in_state = State([])
         circ = Circuit(self.base_circuit.input_modes)
-
+        # Input operation
         for i, op in enumerate(input_op):
             in_state += INPUT_MAPPING[op][0]
             circ.add(INPUT_MAPPING[op][1], 2 * i)
-
+        # Add base circuit
         circ.add(self.base_circuit)
-
+        # Measurement operation
         for i, op in enumerate(output_op):
             circ.add(StateTomo._get_measurement_operator(op), 2 * i)
-
         return circ, in_state

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -151,12 +151,14 @@ class StateTomography:
                 process.
 
         """
-        req_measurements, result_mapping = self._get_required_measurements()
+        req_measurements, result_mapping = (
+            StateTomography._get_required_measurements(self.n_qubits)
+        )
 
         # Generate all circuits and run experiment
         circuits = [
             self._create_circuit(
-                [self._get_measurement_operator(g) for g in gates]
+                [StateTomography._get_measurement_operator(g) for g in gates]
             )
             for gates in req_measurements
         ]
@@ -168,10 +170,12 @@ class StateTomography:
         results_dict = dict(zip(req_measurements, all_results))
         results_dict = {
             c: results_dict[result_mapping[c]]
-            for c in self._get_all_measurements()
+            for c in StateTomography._get_all_measurements(self.n_qubits)
         }
 
-        self._rho = self._calculate_density_matrix(results_dict)
+        self._rho = StateTomography._calculate_density_matrix(
+            self.n_qubits, results_dict
+        )
         return self.rho
 
     def fidelity(self, rho_exp: np.ndarray) -> float:
@@ -189,37 +193,6 @@ class StateTomography:
 
         """
         return state_fidelity(self.rho, rho_exp)
-
-    def _calculate_density_matrix(self, results: dict[str, dict]) -> np.ndarray:
-        """
-        Calculates the density matrix using a provided dictionary of results
-        data. The keys of this dictionary should be the measurement basis and
-        the values the results.
-        """
-        # Process results to find density matrix
-        rho = np.zeros((2**self.n_qubits, 2**self.n_qubits), dtype=complex)
-        for comb, res in results.items():
-            gates = [*comb]
-            total = 0
-            n_counts = 0
-            for s, c in res.items():
-                n_counts += c
-                # Adjust multiplier to account for variation in eigenvalues
-                multiplier = 1
-                for j, gate in enumerate(gates):
-                    if gate == "I" or s[2 * j : 2 * j + 2] == State([1, 0]):
-                        multiplier *= 1
-                    elif s[2 * j : 2 * j + 2] == State([0, 1]):
-                        multiplier *= -1
-                total += multiplier * c
-            total /= (2**self.n_qubits) * n_counts
-            # Calculate tensor product of the operators used
-            mat = self._get_pauli_matrix(gates[0])
-            for g in gates[1:]:
-                mat = np.kron(mat, self._get_pauli_matrix(g))
-            # Updated density matrix
-            rho += total * mat
-        return rho
 
     def _create_circuit(self, measurement_operators: list) -> Circuit:
         """
@@ -240,30 +213,70 @@ class StateTomography:
 
         return circuit
 
-    def _get_all_measurements(self) -> list[str]:
+    @staticmethod
+    def _calculate_density_matrix(
+        n_qubits: int, results: dict[str, dict]
+    ) -> np.ndarray:
+        """
+        Calculates the density matrix using a provided dictionary of results
+        data. The keys of this dictionary should be the measurement basis and
+        the values the results.
+        """
+        # Process results to find density matrix
+        rho = np.zeros((2**n_qubits, 2**n_qubits), dtype=complex)
+        for comb, res in results.items():
+            gates = [*comb]
+            total = 0
+            n_counts = 0
+            for s, c in res.items():
+                n_counts += c
+                # Adjust multiplier to account for variation in eigenvalues
+                multiplier = 1
+                for j, gate in enumerate(gates):
+                    if gate == "I" or s[2 * j : 2 * j + 2] == State([1, 0]):
+                        multiplier *= 1
+                    elif s[2 * j : 2 * j + 2] == State([0, 1]):
+                        multiplier *= -1
+                total += multiplier * c
+            total /= (2**n_qubits) * n_counts
+            # Calculate tensor product of the operators used
+            mat = StateTomography._get_pauli_matrix(gates[0])
+            for g in gates[1:]:
+                mat = np.kron(mat, StateTomography._get_pauli_matrix(g))
+            # Updated density matrix
+            rho += total * mat
+        return rho
+
+    @staticmethod
+    def _get_all_measurements(n_qubits: int) -> list[str]:
         """
         Returns all measurements required for a state tomography of n qubits.
         """
         # Find all measurement combinations
         measurements = list(MEASUREMENT_MAPPING.keys())
-        for _i in range(self.n_qubits - 1):
+        for _i in range(n_qubits - 1):
             measurements = [
                 g1 + g2 for g1 in measurements for g2 in MEASUREMENT_MAPPING
             ]
         return measurements
 
-    def _get_required_measurements(self) -> tuple[list, dict]:
+    @staticmethod
+    def _get_required_measurements(n_qubits: int) -> tuple[list, dict]:
         """
         Calculates reduced list of required measurements assuming that any
         measurements in the I basis can be replaced with a Z measurement.
         A dictionary which maps the full measurements to the reduced basis is
         also returned.
         """
-        mapping = {c: c.replace("I", "Z") for c in self._get_all_measurements()}
+        mapping = {
+            c: c.replace("I", "Z")
+            for c in StateTomography._get_all_measurements(n_qubits)
+        }
         req_measurements = list(set(mapping.values()))
         return req_measurements, mapping
 
-    def _get_measurement_operator(self, measurement: str) -> Circuit:
+    @staticmethod
+    def _get_measurement_operator(measurement: str) -> Circuit:
         """
         Returns the circuit required to transform between a measurement into the
         Z basis.
@@ -272,7 +285,8 @@ class StateTomography:
             raise ValueError("Provided measurement value not recognised.")
         return MEASUREMENT_MAPPING[measurement]
 
-    def _get_pauli_matrix(self, measurement: str) -> np.ndarray:
+    @staticmethod
+    def _get_pauli_matrix(measurement: str) -> np.ndarray:
         """
         Returns the pauli matrix associated with an observable.
         """

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -255,8 +255,9 @@ class StateTomography:
         rho = np.zeros((2**n_qubits, 2**n_qubits), dtype=complex)
         for measurement, result in results.items():
             expectation = StateTomography._calculate_expectation_value(
-                n_qubits, measurement, result
+                measurement, result
             )
+            expectation /= 2**n_qubits
             # Calculate tensor product of the operators used
             mat = StateTomography._get_pauli_matrix(measurement[0])
             for g in measurement[1:]:
@@ -267,8 +268,24 @@ class StateTomography:
 
     @staticmethod
     def _calculate_expectation_value(
-        n_qubits: int, measurement: str, results: dict[str, dict]
+        measurement: str, results: dict[str, dict]
     ) -> float:
+        """
+        Calculates the expectation value for a given measurement and set of
+        results.
+
+        Args:
+
+            measurement (str) : The measurement operator used for the
+                computation.
+
+            results (dict) : A dictionary of measured output states and counts.
+
+        Returns:
+
+            float : The calculated expectation value.
+
+        """
         expectation = 0
         n_counts = 0
         for state, counts in results.items():
@@ -288,7 +305,7 @@ class StateTomography:
                     )
                     raise ValueError(msg)
             expectation += multiplier * counts
-        return expectation / ((2**n_qubits) * n_counts)
+        return expectation / n_counts
 
     @staticmethod
     def _get_all_measurements(n_qubits: int) -> list[str]:

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -91,6 +91,7 @@ class StateTomography:
         self._base_circuit = base_circuit
         self.experiment = experiment
         self.experiment_args = experiment_args
+        self._rho: np.ndarray
 
     @property
     def base_circuit(self) -> Circuit:
@@ -150,54 +151,27 @@ class StateTomography:
                 process.
 
         """
-        # Find measurement combinations
-        combinations = list(MEASUREMENT_MAPPING.keys())
-        for _i in range(self.n_qubits - 1):
-            combinations = [
-                g1 + g2 for g1 in combinations for g2 in MEASUREMENT_MAPPING
-            ]
-
-        result_mapping = {c: c.replace("I", "Z") for c in combinations}
-        measurements = list(set(result_mapping.values()))
+        req_measurements, result_mapping = self._get_required_measurements()
 
         # Generate all circuits and run experiment
         circuits = [
             self._create_circuit(
                 [self._get_measurement_operator(g) for g in gates]
             )
-            for gates in measurements
+            for gates in req_measurements
         ]
         args = self.experiment_args if self.experiment_args is not None else []
         all_results = self.experiment(circuits, *args)
-        results_dict = dict(zip(measurements, all_results))
 
-        # Process results to find density matrix
-        rho = np.zeros((2**self.n_qubits, 2**self.n_qubits), dtype=complex)
-        for comb in combinations:
-            gates = [*comb]
-            results = results_dict[result_mapping[comb]]
-            total = 0
-            n_counts = 0
-            for s, c in results.items():
-                n_counts += c
-                # Adjust multiplier to account for variation in eigenvalues
-                multiplier = 1
-                for j, gate in enumerate(gates):
-                    if gate == "I" or s[2 * j : 2 * j + 2] == State([1, 0]):
-                        multiplier *= 1
-                    elif s[2 * j : 2 * j + 2] == State([0, 1]):
-                        multiplier *= -1
-                total += multiplier * c
-            total /= (2**self.n_qubits) * n_counts
-            # Calculate tensor product of the operators used
-            mat = self._get_pauli_matrix(gates[0])
-            for g in gates[1:]:
-                mat = np.kron(mat, self._get_pauli_matrix(g))
-            # Updated density matrix
-            rho += total * mat
+        # Convert results into dictionary and then mapping to full set of
+        # measurements
+        results_dict = dict(zip(req_measurements, all_results))
+        results_dict = {
+            c: results_dict[result_mapping[c]]
+            for c in self._get_all_measurements()
+        }
 
-        # Assign to attribute then return
-        self._rho: np.ndarray = rho
+        self._rho = self._calculate_density_matrix(results_dict)
         return self.rho
 
     def fidelity(self, rho_exp: np.ndarray) -> float:
@@ -215,6 +189,37 @@ class StateTomography:
 
         """
         return state_fidelity(self.rho, rho_exp)
+
+    def _calculate_density_matrix(self, results: dict[str, dict]) -> np.ndarray:
+        """
+        Calculates the density matrix using a provided dictionary of results
+        data. The keys of this dictionary should be the measurement basis and
+        the values the results.
+        """
+        # Process results to find density matrix
+        rho = np.zeros((2**self.n_qubits, 2**self.n_qubits), dtype=complex)
+        for comb, res in results.items():
+            gates = [*comb]
+            total = 0
+            n_counts = 0
+            for s, c in res.items():
+                n_counts += c
+                # Adjust multiplier to account for variation in eigenvalues
+                multiplier = 1
+                for j, gate in enumerate(gates):
+                    if gate == "I" or s[2 * j : 2 * j + 2] == State([1, 0]):
+                        multiplier *= 1
+                    elif s[2 * j : 2 * j + 2] == State([0, 1]):
+                        multiplier *= -1
+                total += multiplier * c
+            total /= (2**self.n_qubits) * n_counts
+            # Calculate tensor product of the operators used
+            mat = self._get_pauli_matrix(gates[0])
+            for g in gates[1:]:
+                mat = np.kron(mat, self._get_pauli_matrix(g))
+            # Updated density matrix
+            rho += total * mat
+        return rho
 
     def _create_circuit(self, measurement_operators: list) -> Circuit:
         """
@@ -234,6 +239,29 @@ class StateTomography:
             circuit.add(op, 2 * i)
 
         return circuit
+
+    def _get_all_measurements(self) -> list[str]:
+        """
+        Returns all measurements required for a state tomography of n qubits.
+        """
+        # Find all measurement combinations
+        measurements = list(MEASUREMENT_MAPPING.keys())
+        for _i in range(self.n_qubits - 1):
+            measurements = [
+                g1 + g2 for g1 in measurements for g2 in MEASUREMENT_MAPPING
+            ]
+        return measurements
+
+    def _get_required_measurements(self) -> tuple[list, dict]:
+        """
+        Calculates reduced list of required measurements assuming that any
+        measurements in the I basis can be replaced with a Z measurement.
+        A dictionary which maps the full measurements to the reduced basis is
+        also returned.
+        """
+        mapping = {c: c.replace("I", "Z") for c in self._get_all_measurements()}
+        req_measurements = list(set(mapping.values()))
+        return req_measurements, mapping
 
     def _get_measurement_operator(self, measurement: str) -> Circuit:
         """

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -162,8 +162,10 @@ class StateTomography:
             )
             for gates in req_measurements
         ]
-        args = self.experiment_args if self.experiment_args is not None else []
-        all_results = self.experiment(circuits, *args)
+        all_results = self.experiment(
+            circuits,
+            *(self.experiment_args if self.experiment_args is not None else []),
+        )
 
         # Convert results into dictionary and then mapping to full set of
         # measurements

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -20,7 +20,7 @@ import numpy as np
 from .. import qubit
 from ..sdk.circuit import Circuit
 from ..sdk.state import State
-from .utils import state_fidelity
+from .utils import PAULI_MAPPING, state_fidelity
 
 _y_measure = Circuit(2)
 _y_measure.add(qubit.S())
@@ -32,13 +32,6 @@ MEASUREMENT_MAPPING = {
     "X": qubit.H(),
     "Y": _y_measure,
     "Z": qubit.I(),
-}
-
-PAULI_MAPPING = {
-    "I": np.array([[1, 0], [0, 1]]),
-    "X": np.array([[0, 1], [1, 0]]),
-    "Y": np.array([[0, -1j], [1j, 0]]),
-    "Z": np.array([[1, 0], [0, -1]]),
 }
 
 
@@ -268,7 +261,7 @@ class StateTomography:
 
     @staticmethod
     def _calculate_expectation_value(
-        measurement: str, results: dict[str, dict]
+        measurement: str, results: dict[str, int]
     ) -> float:
         """
         Calculates the expectation value for a given measurement and set of

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -23,7 +23,7 @@ def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
 
     Args:
 
-        rho (np.ndarray) : The density matrix of the quantum state.
+        rho (np.ndarray) : The calculated density matrix of the quantum state.
 
         rho_exp (np.ndarray) : The expected density matrix.
 
@@ -34,10 +34,10 @@ def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
     """
     rho_exp = np.array(rho_exp)
     rho_root = sqrtm(np.array(rho))
-    if rho_exp.shape != rho_root.shape:
+    if rho_root.shape != rho_exp.shape:
         msg = (
             "Mismatch in dimensions between provided density matrices, "
-            f"{rho_root.shape} & {rho_root.shape}."
+            f"{rho_root.shape} & {rho_exp.shape}."
         )
         raise ValueError(msg)
     inner = rho_root @ rho_exp @ rho_root
@@ -46,8 +46,24 @@ def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
 
 def process_fidelity(chi: np.ndarray, chi_exp: np.ndarray) -> float:
     """
-    Desc
+    Calculates the fidelity of a process compared to an expected chi matrix.
+
+    Args:
+
+        chi (np.ndarray) : The calculated chi matrix for the process.
+
+        chi_exp (np.ndarray) : The expected chi matrix.
+
+    Returns:
+
+        float : The calculated fidelity value.
+
     """
-    chi * chi_exp
+    if chi.shape != chi_exp.shape:
+        msg = (
+            "Mismatch in dimensions between provided density matrices, "
+            f"{chi.shape} & {chi_exp.shape}."
+        )
+        raise ValueError(msg)
     raise NotImplementedError("Fidelity not yet implemented.")
     return 0

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -15,6 +15,13 @@
 import numpy as np
 from scipy.linalg import sqrtm
 
+PAULI_MAPPING: dict[str, np.ndarray] = {
+    "I": np.array([[1, 0], [0, 1]]),
+    "X": np.array([[0, 1], [1, 0]]),
+    "Y": np.array([[0, -1j], [1j, 0]]),
+    "Z": np.array([[1, 0], [0, -1]]),
+}
+
 
 def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
     """
@@ -65,8 +72,8 @@ def process_fidelity(chi: np.ndarray, chi_exp: np.ndarray) -> float:
             f"{chi.shape} & {chi_exp.shape}."
         )
         raise ValueError(msg)
-    raise NotImplementedError("Fidelity not yet implemented.")
-    return 0
+    n_qubits = np.emath.logn(4, chi.shape[0])
+    return state_fidelity(chi / 2**n_qubits, chi_exp / 2**n_qubits)
 
 
 def density_from_state(state: list | np.ndarray) -> np.ndarray:
@@ -85,3 +92,21 @@ def density_from_state(state: list | np.ndarray) -> np.ndarray:
     """
     state = np.array(state)
     return np.outer(state, np.conj(state.T))
+
+
+def choi_from_unitary(unitary: np.ndarray) -> np.ndarray:
+    """
+    Calculates the expected choi matrix from a given unitary representation of a
+    process.
+
+    Args:
+
+        unitary (np.ndarray) : The unitary representation of the gate.
+
+    Returns:
+
+        np.ndarray : The calculated choi matix.
+
+    """
+    unitary = np.array(unitary)
+    return np.outer(unitary.flatten(), np.conj(unitary.flatten()))

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -67,3 +67,21 @@ def process_fidelity(chi: np.ndarray, chi_exp: np.ndarray) -> float:
         raise ValueError(msg)
     raise NotImplementedError("Fidelity not yet implemented.")
     return 0
+
+
+def density_from_state(state: list | np.ndarray) -> np.ndarray:
+    """
+    Calculates the expected density matrix from a given state.
+
+    Args:
+
+        state (list | np.ndarray) : The vector representation of the state for
+            which the density matrix should be calculated.
+
+    Returns:
+
+        np.ndarray : The calculated density matrix.
+
+    """
+    state = np.array(state)
+    return np.outer(state, np.conj(state.T))

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -51,29 +51,29 @@ def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
     return abs(np.trace(sqrtm(inner)))
 
 
-def process_fidelity(chi: np.ndarray, chi_exp: np.ndarray) -> float:
+def process_fidelity(choi: np.ndarray, choi_exp: np.ndarray) -> float:
     """
-    Calculates the fidelity of a process compared to an expected chi matrix.
+    Calculates the fidelity of a process compared to an expected choi matrix.
 
     Args:
 
-        chi (np.ndarray) : The calculated chi matrix for the process.
+        choi (np.ndarray) : The calculated choi matrix for the process.
 
-        chi_exp (np.ndarray) : The expected chi matrix.
+        choi_exp (np.ndarray) : The expected choi matrix.
 
     Returns:
 
         float : The calculated fidelity value.
 
     """
-    if chi.shape != chi_exp.shape:
+    if choi.shape != choi_exp.shape:
         msg = (
             "Mismatch in dimensions between provided density matrices, "
-            f"{chi.shape} & {chi_exp.shape}."
+            f"{choi.shape} & {choi_exp.shape}."
         )
         raise ValueError(msg)
-    n_qubits = np.emath.logn(4, chi.shape[0])
-    return state_fidelity(chi / 2**n_qubits, chi_exp / 2**n_qubits)
+    n_qubits = int(np.emath.logn(4, choi.shape[0]))
+    return state_fidelity(choi / 2**n_qubits, choi_exp / 2**n_qubits)
 
 
 def density_from_state(state: list | np.ndarray) -> np.ndarray:
@@ -105,7 +105,7 @@ def choi_from_unitary(unitary: np.ndarray) -> np.ndarray:
 
     Returns:
 
-        np.ndarray : The calculated choi matix.
+        np.ndarray : The calculated choi matrix.
 
     """
     unitary = np.array(unitary)

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -42,3 +42,12 @@ def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
         raise ValueError(msg)
     inner = rho_root @ rho_exp @ rho_root
     return abs(np.trace(sqrtm(inner)))
+
+
+def process_fidelity(chi: np.ndarray, chi_exp: np.ndarray) -> float:
+    """
+    Desc
+    """
+    chi * chi_exp
+    raise NotImplementedError("Fidelity not yet implemented.")
+    return 0

--- a/tests/tomography/process_test.py
+++ b/tests/tomography/process_test.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from lightworks import PostSelection, emulator, qubit
+from lightworks.tomography import ProcessTomography
+
+
+def experiment(circuits, inputs, n_qubits):
+    """
+    Experiment function for testing process tomography. The number of qubits
+    should be specified in experiment_args.
+    """
+    post_select = PostSelection()
+    for i in range(n_qubits):
+        post_select.add((2 * i, 2 * i + 1), 1)
+    results = []
+    for circ, in_s in zip(circuits, inputs):
+        sampler = emulator.Sampler(circ, in_s, backend="slos")
+        results.append(sampler.sample_N_outputs(10000, post_select=post_select))
+    return results
+
+
+h_exp = np.zeros((4, 4), dtype=complex)
+h_exp[1, 1] = 0.5
+h_exp[1, 3] = 0.5
+h_exp[3, 1] = 0.5
+h_exp[3, 3] = 0.5
+
+chi_exp = np.zeros((16, 16), dtype=complex)
+# fmt: off
+positive = np.array([
+    [0, 0], [0, 1], [1, 0], [1, 1], [12, 0], [12, 1], [0, 12], [1, 12],
+    [12, 12], [13, 13]
+])
+negative = np.array(
+    [[13, 0], [13, 1], [0, 13], [1, 13], [12, 13], [13, 12]]
+)
+# fmt: on
+chi_exp[positive[:, 0], positive[:, 1]] = 0.25
+chi_exp[negative[:, 0], negative[:, 1]] = -0.25
+
+
+class TestProcessTomography:
+    """
+    Unit tests for ProcessTomography routine.
+    """
+
+    def setup_class(self):
+        """
+        Runs process tomography experiments so results can be reused
+        """
+        # Hadamard tomography
+        n_qubits = 1
+        circ = qubit.H()
+        self.h_tomo = ProcessTomography(n_qubits, circ, experiment, [n_qubits])
+        self.h_tomo.process()
+        # CNOT tomography
+        n_qubits = 2
+        circ = qubit.CNOT()
+        self.cnot_tomo = ProcessTomography(
+            n_qubits, circ, experiment, [n_qubits]
+        )
+        self.cnot_tomo.process()
+
+    def test_hadamard_chi(self):
+        """
+        Checks process tomography of the Hadamard gate produces the expected chi
+        matrix.
+        """
+        assert self.h_tomo.chi == pytest.approx(h_exp, abs=1e-2)
+
+    def test_hadamard_fidelity(self):
+        """
+        Checks fidelity of hadamard gate process matrix is close to 1.
+        """
+        assert self.h_tomo.fidelity(h_exp) == pytest.approx(1, 1e-2)
+
+    def test_cnot_chi(self):
+        """
+        Checks process tomography of the CNOT gate produces the expected chi
+        matrix and the fidelity is calculated to be 1.
+        """
+        assert self.cnot_tomo.chi == pytest.approx(chi_exp, abs=1e-2)
+
+    def test_cnot_fidelity(self):
+        """
+        Checks fidelity of CNOT gate process matrix is close to 1.
+        """
+        assert self.cnot_tomo.fidelity(chi_exp) == pytest.approx(1, 1e-2)

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -203,3 +203,24 @@ class TestStateTomography:
         rho_exp[0, 0] = 1
         assert rho == pytest.approx(rho_exp, abs=1e-2)
         assert tomo.fidelity(rho_exp) == pytest.approx(1, 1e-3)
+
+    @pytest.mark.parametrize("n_qubits", [1, 3])
+    def test_number_of_measurements(self, n_qubits):
+        """
+        Confirms that the number of measurements for a full state tomography is
+        is 4^n_qubits.
+        """
+        assert (
+            len(StateTomography._get_all_measurements(n_qubits)) == 4**n_qubits
+        )
+
+    @pytest.mark.parametrize("n_qubits", [1, 3])
+    def test_number_of_required_measurements(self, n_qubits):
+        """
+        Confirms that the number of required measurements for a state tomography
+        is 3^n_qubits.
+        """
+        assert (
+            len(StateTomography._get_required_measurements(n_qubits)[0])
+            == 3**n_qubits
+        )

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -67,6 +67,7 @@ class TestUtils:
             choi_from_unitary([[2**-0.5, 2**-0.5], [2**-0.5, -(2**-0.5)]]),
             choi_from_unitary(U_CNOT),
             choi_from_unitary(U_CCNOT),
+            choi_from_unitary(U_CCZ),
         ],
     )
     def test_process_fidelity(self, choi):

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 from lightworks import random_unitary
-from lightworks.tomography import state_fidelity
+from lightworks.tomography import process_fidelity, state_fidelity
 
 
 class TestUtils:
@@ -37,7 +37,7 @@ class TestUtils:
         Validate that fidelity value is always 1 when using two identical
         matrices.
         """
-        rho = np.array(rho)
+        rho = np.array(rho, dtype=complex)
         assert state_fidelity(rho, rho) == pytest.approx(1, 1e-6)
 
     def test_state_fidelity_dim_mismatch(self):
@@ -47,3 +47,27 @@ class TestUtils:
         """
         with pytest.raises(ValueError, match="dimensions"):
             state_fidelity(random_unitary(3), random_unitary(4))
+
+    @pytest.mark.parametrize(
+        "rho",
+        [
+            [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
+            [[0, 0, 0, 0], [0, 0.5, 0, 0.5], [0, 0, 0, 0], [0, 0.5, 0, 0.5]],
+            [[0, 0, 0, 0], [0, 0.5, 0, 0.5j], [0, 0, 0, 0], [0, -0.5j, 0, 0.5]],
+        ],
+    )
+    def test_process_fidelity(self, rho):
+        """
+        Validate that fidelity value is always 1 when using two identical
+        matrices.
+        """
+        rho = np.array(rho, dtype=complex)
+        assert process_fidelity(rho, rho) == pytest.approx(1, 1e-6)
+
+    def test_process_fidelity_dim_mismatch(self):
+        """
+        Check an error is raised if there is a mismatch in dimensions between
+        density matrices.
+        """
+        with pytest.raises(ValueError, match="dimensions"):
+            process_fidelity(random_unitary(3), random_unitary(4))

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -16,7 +16,11 @@ import numpy as np
 import pytest
 
 from lightworks import random_unitary
-from lightworks.tomography import process_fidelity, state_fidelity
+from lightworks.tomography import (
+    density_from_state,
+    process_fidelity,
+    state_fidelity,
+)
 
 
 class TestUtils:
@@ -71,3 +75,27 @@ class TestUtils:
         """
         with pytest.raises(ValueError, match="dimensions"):
             process_fidelity(random_unitary(3), random_unitary(4))
+
+    def test_basic_density_matrix_calc(self):
+        """
+        Desc
+        """
+        rho = density_from_state([1, 0, 0, 0])
+        assert (
+            rho
+            == np.array(
+                [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+            )
+        ).all()
+
+    def test_bell_state_density_matrix_calc(self):
+        """
+        desc
+        """
+        rho = density_from_state([2**-0.5, 0, 0, 2**-0.5])
+        assert (
+            rho.round(5)
+            == np.array(
+                [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
+            )
+        ).all()

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -23,6 +23,12 @@ from lightworks.tomography import (
     state_fidelity,
 )
 
+U_CNOT = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
+U_CCNOT = np.identity(8)
+U_CCNOT[6:, :] = U_CCNOT[7:5:-1, :]
+U_CCZ = np.identity(8)
+U_CCZ[7, 7] = -1
+
 
 class TestUtils:
     """
@@ -59,6 +65,8 @@ class TestUtils:
             choi_from_unitary([[0, 1], [1, 0]]),
             choi_from_unitary([[0, -1j], [1j, 0]]),
             choi_from_unitary([[2**-0.5, 2**-0.5], [2**-0.5, -(2**-0.5)]]),
+            choi_from_unitary(U_CNOT),
+            choi_from_unitary(U_CCNOT),
         ],
     )
     def test_process_fidelity(self, choi):

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -17,6 +17,7 @@ import pytest
 
 from lightworks import random_unitary
 from lightworks.tomography import (
+    choi_from_unitary,
     density_from_state,
     process_fidelity,
     state_fidelity,
@@ -53,19 +54,19 @@ class TestUtils:
             state_fidelity(random_unitary(3), random_unitary(4))
 
     @pytest.mark.parametrize(
-        "rho",
+        "choi",
         [
-            [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
-            [[0, 0, 0, 0], [0, 0.5, 0, 0.5], [0, 0, 0, 0], [0, 0.5, 0, 0.5]],
-            [[0, 0, 0, 0], [0, 0.5, 0, 0.5j], [0, 0, 0, 0], [0, -0.5j, 0, 0.5]],
+            choi_from_unitary([[0, 1], [1, 0]]),
+            choi_from_unitary([[0, -1j], [1j, 0]]),
+            choi_from_unitary([[2**-0.5, 2**-0.5], [2**-0.5, -(2**-0.5)]]),
         ],
     )
-    def test_process_fidelity(self, rho):
+    def test_process_fidelity(self, choi):
         """
         Validate that fidelity value is always 1 when using two identical
         matrices.
         """
-        rho = np.array(rho, dtype=complex)
+        rho = np.array(choi, dtype=complex)
         assert process_fidelity(rho, rho) == pytest.approx(1, 1e-6)
 
     def test_process_fidelity_dim_mismatch(self):
@@ -78,7 +79,7 @@ class TestUtils:
 
     def test_basic_density_matrix_calc(self):
         """
-        Desc
+        Checks the density matrix of the two qubit state |00> is correct.
         """
         rho = density_from_state([1, 0, 0, 0])
         assert (
@@ -90,12 +91,29 @@ class TestUtils:
 
     def test_bell_state_density_matrix_calc(self):
         """
-        desc
+        Checks the calculated density matrix for a bell state is correct.
         """
         rho = density_from_state([2**-0.5, 0, 0, 2**-0.5])
         assert (
             rho.round(5)
             == np.array(
                 [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
+            )
+        ).all()
+
+    def test_hadamard_choi(self):
+        """
+        Checks that the calculated choi matrix for the hadamard gate is correct.
+        """
+        choi = choi_from_unitary([[2**-0.5, 2**-0.5], [2**-0.5, -(2**-0.5)]])
+        assert (
+            choi.round(5)
+            == np.array(
+                [
+                    [0.5, 0.5, 0.5, -0.5],
+                    [0.5, 0.5, 0.5, -0.5],
+                    [0.5, 0.5, 0.5, -0.5],
+                    [-0.5, -0.5, -0.5, 0.5],
+                ]
             )
         ).all()


### PR DESCRIPTION
# Summary

Closes #88 by adding an initial implementation of process tomography, which enables calculation of the choi matrix. There is also a fidelity function, though further work needs to be done on identifying the optimal form of this.

## Full list of changes

- Routines to perform process tomography for calculation of the choi matrix.
- Functionalised StateTomography so the components could be called by ProcessTomography.
- Added fidelity calculation for process tomography.
- Expanded on unit tests.
- Include process tomography and utilities in tomography reference section of the docs.
