### PR TITLE
Gate fidelity

### DIFF
--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -19,6 +19,7 @@ Lightworks Tomography
 A set of tools for quantum state & process tomography on a system.
 """
 
+from .gate_fidelity import GateFidelity
 from .process_tomography_li import LIProcessTomography
 from .process_tomography_mle import MLEProcessTomography
 from .state_tomography import StateTomography

--- a/lightworks/tomography/gate_fidelity.py
+++ b/lightworks/tomography/gate_fidelity.py
@@ -46,14 +46,7 @@ class GateFidelity(ProcessTomography):
 
     """
 
-    @property
-    def choi(self) -> None:
-        """
-        Overwrites default behaviour for return of choi matrix.
-        """
-        raise AttributeError("Gate fidelity does not computer choi matrix")
-
-    def process(self, target_process: np.ndarray) -> float:
+    def fidelity(self, target_process: np.ndarray) -> float:
         """
         Calculates gate fidelity for an expected target process
 
@@ -70,7 +63,9 @@ class GateFidelity(ProcessTomography):
         all_inputs = combine_all(TOMO_INPUTS, self.n_qubits)
         results = self._run_required_experiments(all_inputs)
         # Sorted results per input
-        remapped_results = {k[0]: {} for k in results}
+        remapped_results: dict[str, dict[str, dict]] = {
+            k[0]: {} for k in results
+        }
         for (k1, k2), r in results.items():
             remapped_results[k1][k2] = r
         # Calculate density matrices
@@ -94,23 +89,9 @@ class GateFidelity(ProcessTomography):
         dim = 2**self.n_qubits
         return np.real((total + dim**2) / (dim**2 * (dim + 1))).item()
 
-    def fidelity(self, target_process: np.ndarray) -> float:
-        """
-        Calculates the average fidelity using a target process.
-
-        Args:
-
-            target_process (np.ndarray) : The unitary matrix corresponding to
-                the target process. The dimension of this should be 2^n_qubits.
-
-        Returns:
-
-            float : The calculated fidelity.
-
-        """
-        return self.process(target_process)
-
-    def _calculate_alpha_and_u_basis(self) -> np.ndarray:
+    def _calculate_alpha_and_u_basis(
+        self,
+    ) -> tuple[np.ndarray, list[np.ndarray]]:
         """
         Calculates the pauli matrix basis to use for the calculation and finds
         the coefficients of the alpha matrix used which can be used to the

--- a/lightworks/tomography/gate_fidelity.py
+++ b/lightworks/tomography/gate_fidelity.py
@@ -1,0 +1,90 @@
+# Copyright 2024 Aegiq Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from .mappings import RHO_MAPPING
+from .process_tomography import ProcessTomography
+from .utils import _calculate_density_matrix, combine_all, state_fidelity
+
+TOMO_INPUTS = ["Z+", "Z-", "X+", "X-", "Y+", "Y-"]
+
+
+class GateFidelity(ProcessTomography):
+    """
+    Computers the average gate fidelity
+
+    Args:
+
+        n_qubits (int) : The number of qubits that will be used as part of the
+            tomography.
+
+        base_circuit (Circuit) : An initial circuit which produces the required
+            output state and can be modified for performing tomography. It is
+            required that the number of circuit input modes equals 2 * the
+            number of qubits.
+
+        experiment (Callable) : A function for performing the required
+            tomography experiments. This should accept a list of circuits and a
+            list of inputs and then return a list of results to process.
+
+        experiment_args (list | None) : Optionally provide additional arguments
+            which will be passed directly to the experiment function.
+
+    """
+
+    @property
+    def choi(self) -> None:
+        """
+        Overwrites default behaviour for return of choi matrix.
+        """
+        raise AttributeError("Gate fidelity does not computer choi matrix")
+
+    def process(self, target_process: np.ndarray) -> float:
+        """
+        Calculates gate fidelity for an expected target process
+
+        Args:
+
+            target_process (np.ndarray) : The unitary matrix corresponding to
+                the target process. The dimension of this should be 2^n_qubits.
+
+        Returns:
+
+            float : The calculated fidelity.
+
+        """
+        all_inputs = combine_all(TOMO_INPUTS, self.n_qubits)
+        results = self._run_required_experiments(all_inputs)
+        # Sorted results per input
+        remapped_results = {k[0]: {} for k in results}
+        for (k1, k2), r in results.items():
+            remapped_results[k1][k2] = r
+        # Calculate density matrices
+        rhos = {
+            k: _calculate_density_matrix(v, self.n_qubits)
+            for k, v in remapped_results.items()
+        }
+        rhos_exp = {}
+        for indices in all_inputs:
+            index = indices.split(",")
+            rho_e = RHO_MAPPING[index[0]]
+            for i in index[1:]:
+                rho_e = np.kron(rho_e, RHO_MAPPING[i])
+            rhos_exp[indices] = (
+                np.conj(target_process).T @ rho_e @ target_process
+            )
+        return np.mean(
+            [state_fidelity(rhos[i], rhos_exp[i]) for i in all_inputs],
+        ).item()

--- a/lightworks/tomography/gate_fidelity.py
+++ b/lightworks/tomography/gate_fidelity.py
@@ -46,7 +46,17 @@ class GateFidelity(ProcessTomography):
 
     """
 
-    def fidelity(self, target_process: np.ndarray) -> float:
+    @property
+    def fidelity(self) -> float:
+        """Returns the calculated fidelity of a process."""
+        if not hasattr(self, "_fidelity"):
+            raise AttributeError(
+                "Fidelity has not yet been calculated, this can be achieved "
+                "with the process method."
+            )
+        return self._fidelity
+
+    def process(self, target_process: np.ndarray) -> float:
         """
         Calculates gate fidelity for an expected target process
 
@@ -60,6 +70,8 @@ class GateFidelity(ProcessTomography):
             float : The calculated fidelity.
 
         """
+        target_process = np.array(target_process)
+        # Run all required tomography experiments
         all_inputs = combine_all(TOMO_INPUTS, self.n_qubits)
         results = self._run_required_experiments(all_inputs)
         # Sorted results per input
@@ -87,7 +99,8 @@ class GateFidelity(ProcessTomography):
                 )
         # Use total within calculation and return
         dim = 2**self.n_qubits
-        return np.real((total + dim**2) / (dim**2 * (dim + 1))).item()
+        self._fidelity = np.real((total + dim**2) / (dim**2 * (dim + 1))).item()
+        return self.fidelity
 
     def _calculate_alpha_and_u_basis(
         self,

--- a/lightworks/tomography/process_tomography.py
+++ b/lightworks/tomography/process_tomography.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta, abstractmethod
 from types import FunctionType, MethodType
 from typing import Callable
-
-import numpy as np
 
 from ..sdk.circuit import Circuit
 from ..sdk.state import State
@@ -24,13 +21,12 @@ from .mappings import INPUT_MAPPING, MEASUREMENT_MAPPING
 from .utils import (
     _get_required_tomo_measurements,
     _get_tomo_measurements,
-    process_fidelity,
 )
 
 TOMO_INPUTS = ["Z+", "Z-", "X+", "Y+"]
 
 
-class ProcessTomography(metaclass=ABCMeta):
+class ProcessTomography:
     """
     Process tomography base class, implements some of the common methods
     required across different approaches.
@@ -79,7 +75,6 @@ class ProcessTomography(metaclass=ABCMeta):
         self._base_circuit = base_circuit
         self.experiment = experiment
         self.experiment_args = experiment_args
-        self._choi: np.ndarray
 
     @property
     def base_circuit(self) -> Circuit:
@@ -115,29 +110,6 @@ class ProcessTomography(metaclass=ABCMeta):
                 "qubit modes."
             )
         self._experiment = value
-
-    @property
-    def choi(self) -> np.ndarray:
-        """Returns the calculate choi matrix for a circuit."""
-        if not hasattr(self, "_choi"):
-            raise AttributeError(
-                "Choi matrix has not yet been calculated, this can be achieved "
-                "with the process method."
-            )
-        return self._choi
-
-    @abstractmethod
-    def process(self) -> np.ndarray:
-        """
-        Performs tomography using the selected algorithm.
-        """
-
-    def fidelity(self, choi_exp: np.ndarray) -> float:
-        """
-        Calculates fidelity of the calculated choi matrix compared to the
-        expected one.
-        """
-        return process_fidelity(self.choi, choi_exp)
 
     def _create_circuit_and_input(
         self, input_op: str, output_op: str

--- a/lightworks/tomography/process_tomography_li.py
+++ b/lightworks/tomography/process_tomography_li.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from .mappings import PAULI_MAPPING, RHO_MAPPING
 from .process_tomography import ProcessTomography
-from .utils import _calculate_expectation_value, combine_all
+from .utils import _calculate_expectation_value, combine_all, process_fidelity
 
 TOMO_INPUTS = ["Z+", "Z-", "X+", "Y+"]
 
@@ -44,6 +44,16 @@ class LIProcessTomography(ProcessTomography):
             which will be passed directly to the experiment function.
 
     """
+
+    @property
+    def choi(self) -> np.ndarray:
+        """Returns the calculate choi matrix for a circuit."""
+        if not hasattr(self, "_choi"):
+            raise AttributeError(
+                "Choi matrix has not yet been calculated, this can be achieved "
+                "with the process method."
+            )
+        return self._choi
 
     def process(self) -> np.ndarray:
         """
@@ -77,6 +87,13 @@ class LIProcessTomography(ProcessTomography):
         )
         self._choi = choi.reshape(dim**2, dim**2)
         return self.choi
+
+    def fidelity(self, choi_exp: np.ndarray) -> float:
+        """
+        Calculates fidelity of the calculated choi matrix compared to the
+        expected one.
+        """
+        return process_fidelity(self.choi, choi_exp)
 
     def _calculate_expectation_values(
         self, results: dict[tuple[str, str], dict]

--- a/lightworks/tomography/process_tomography_mle.py
+++ b/lightworks/tomography/process_tomography_mle.py
@@ -22,6 +22,7 @@ from .utils import (
     _calculate_expectation_value,
     _get_tomo_measurements,
     combine_all,
+    process_fidelity,
     unvec,
     vec,
 )
@@ -53,6 +54,16 @@ class MLEProcessTomography(ProcessTomography):
 
     """
 
+    @property
+    def choi(self) -> np.ndarray:
+        """Returns the calculate choi matrix for a circuit."""
+        if not hasattr(self, "_choi"):
+            raise AttributeError(
+                "Choi matrix has not yet been calculated, this can be achieved "
+                "with the process method."
+            )
+        return self._choi
+
     def process(self) -> np.ndarray:
         """
         Performs process tomography with the configured elements and calculates
@@ -76,6 +87,13 @@ class MLEProcessTomography(ProcessTomography):
         mle = MLETomographyAlgorithm(self.n_qubits)
         self._choi = mle.pgdb(nij)
         return self.choi
+
+    def fidelity(self, choi_exp: np.ndarray) -> float:
+        """
+        Calculates fidelity of the calculated choi matrix compared to the
+        expected one.
+        """
+        return process_fidelity(self.choi, choi_exp)
 
 
 class MLETomographyAlgorithm:

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -138,11 +138,22 @@ def combine_all(value: Any, n: int) -> None:  # noqa: ARG001
 @combine_all.register
 def _combine_all_list(value: list[str], n: int) -> list:
     """
-    Sums values within list.
+    Sums string values within list.
     """
     result = list(value)
     for _ in range(n - 1):
         result = [v1 + "," + v2 for v1 in result for v2 in value]
+    return result
+
+
+@combine_all.register
+def _combine_all_list_array(value: list[np.ndarray], n: int) -> list:
+    """
+    Performs tensor product of all combinations of arrays within list.
+    """
+    result = list(value)
+    for _ in range(n - 1):
+        result = [np.kron(v1, v2) for v1 in result for v2 in value]
     return result
 
 

--- a/tests/tomography/gate_fidelity_test.py
+++ b/tests/tomography/gate_fidelity_test.py
@@ -15,7 +15,7 @@
 import pytest
 
 from lightworks import PostSelection, emulator, qubit
-from lightworks.tomography import MLEProcessTomography, choi_from_unitary
+from lightworks.tomography import GateFidelity
 
 
 def experiment(circuits, inputs, n_qubits):
@@ -35,58 +35,37 @@ def experiment(circuits, inputs, n_qubits):
     return results
 
 
-h_exp = choi_from_unitary([[2**-0.5, 2**-0.5], [2**-0.5, -(2**-0.5)]])
-
-cnot_exp = choi_from_unitary(
-    [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
-)
-
-
-class TestMLEProcessTomography:
+class TestGateFidelity:
     """
-    Unit tests for MLEProcessTomography routine.
+    Unit tests for checking GateFidelity routine.
     """
 
     def setup_class(self):
         """
-        Runs process tomography experiments so results can be reused.
+        Runs experiments so results can be reused.
         """
-        # Hadamard tomography
+        # Hadamard fidelity
         n_qubits = 1
         circ = qubit.H()
-        self.h_tomo = MLEProcessTomography(
-            n_qubits, circ, experiment, [n_qubits]
-        )
-        self.h_tomo.process()
-        # CNOT tomography
+        self.h_tomo = GateFidelity(n_qubits, circ, experiment, [n_qubits])
+        self.h_tomo.process([[2**-0.5, 2**-0.5], [2**-0.5, -(2**-0.5)]])
+        # CNOT fidelity
         n_qubits = 2
         circ = qubit.CNOT()
-        cnot_tomo = MLEProcessTomography(n_qubits, circ, experiment, [n_qubits])
-        cnot_tomo.process()
+        cnot_tomo = GateFidelity(n_qubits, circ, experiment, [n_qubits])
+        cnot_tomo.process(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
+        )
         self.cnot_tomo = cnot_tomo
-
-    def test_hadamard_choi(self):
-        """
-        Checks process tomography of the Hadamard gate produces the expected
-        choi matrix.
-        """
-        assert self.h_tomo.choi == pytest.approx(h_exp, abs=5e-2)
 
     def test_hadamard_fidelity(self):
         """
-        Checks fidelity of hadamard gate process matrix is close to 1.
+        Checks fidelity of hadamard gate process is close to 1.
         """
-        assert self.h_tomo.fidelity(h_exp) == pytest.approx(1, 1e-2)
-
-    def test_cnot_choi(self):
-        """
-        Checks process tomography of the CNOT gate produces the expected choi
-        matrix and the fidelity is calculated to be 1.
-        """
-        assert self.cnot_tomo.choi == pytest.approx(cnot_exp, abs=5e-2)
+        assert self.h_tomo.fidelity == pytest.approx(1, 1e-2)
 
     def test_cnot_fidelity(self):
         """
-        Checks fidelity of CNOT gate process matrix is close to 1.
+        Checks fidelity of CNOT gate process is close to 1.
         """
-        assert self.cnot_tomo.fidelity(cnot_exp) == pytest.approx(1, 1e-2)
+        assert self.cnot_tomo.fidelity == pytest.approx(1, 1e-2)

--- a/tests/tomography/process_li_test.py
+++ b/tests/tomography/process_li_test.py
@@ -49,7 +49,7 @@ class TestLIProcessTomography:
 
     def setup_class(self):
         """
-        Runs process tomography experiments so results can be reused
+        Runs process tomography experiments so results can be reused.
         """
         # Hadamard tomography
         n_qubits = 1


### PR DESCRIPTION
# Summary

Adds the average gate fidelity calculation from arXiv:quant-ph/0205035 into the tomography module. Which allows for estimation of the fidelity from a set of state tomography experiments.

## Full list of changes

- TODO
