### PR TITLE
Result improvement

### DIFF
--- a/docs/source/emulator/simulator.rst
+++ b/docs/source/emulator/simulator.rst
@@ -51,7 +51,7 @@ This will return a :doc:`../emulator_reference/simulation_result` object. We can
 
 .. code-block:: Python
 
-    print(results[output_state])
+    print(results[input_state])
     # {lightworks.State(|0,0,1,1>): np.complex128(0.037523401912278494-0.25889120714091474j)}
 
     print(results[input_state, output_state])

--- a/docs/source/emulator/simulator.rst
+++ b/docs/source/emulator/simulator.rst
@@ -47,12 +47,12 @@ To find the probability amplitude between then input :math:`\ket{1,1,0,0}` and o
 
     results = sim.simulate(input_state, output_state)
 
-This will return a :doc:`../emulator_reference/simulation_result` object. We can access data for specific input and outputs using the ``[]`` operator on the object. The behaviour of this slightly varies depending on whether the simulation used one or multiple inputs. In the single input case it is possible to do ``[output_state]`` to get the value for a particular output, whereas for multiple inputs ``[input_state]`` will return all possible outputs for an input and ``[input_state, output_state]`` will produce a singular value for the selected combination. As only one input was used above the following are therefore equivalent:
+This will return a :doc:`../emulator_reference/simulation_result` object. We can access data for specific input and outputs using the ``[]`` operator on the object. It is possible to do ``[input_state]`` to get all results for a particular input, and ``[input_state, output_state]`` will produce the singular value for the selected input/output combination.
 
 .. code-block:: Python
 
     print(results[output_state])
-    # Output: (0.037523401912278494-0.25889120714091474j)
+    # {lightworks.State(|0,0,1,1>): np.complex128(0.037523401912278494-0.25889120714091474j)}
 
     print(results[input_state, output_state])
     # Output: (0.037523401912278494-0.25889120714091474j)
@@ -71,7 +71,7 @@ Using the same Simulator object created above, it is also possible to see some o
 
 .. code-block:: Python
 
-    results = sim.simulate(input, output)
+    results = sim.simulate(input_state)
 
     # View all outputs
     print(results.outputs)
@@ -80,7 +80,7 @@ Using the same Simulator object created above, it is also possible to see some o
     #          State(|0,0,1,1>), State(|0,0,0,2>)]
 
     # Select one output to view
-    print(results[lw.State([0,2,0,0])])
+    print(results[input_state, lw.State([0,2,0,0])])
     # Output: (0.38752992893519644-0.3073703647306116j)
 
 Multiple inputs and outputs can also be used by specifying them as lists of State objects. When doing this, the probability amplitude between all combinations of provided inputs and outputs will be calculated.

--- a/lightworks/emulator/results/sampling_result.py
+++ b/lightworks/emulator/results/sampling_result.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Iterable, Iterator
+from typing import Any
 
 import matplotlib.figure
 import matplotlib.pyplot as plt
@@ -23,7 +23,7 @@ from ...sdk.state import State
 from ..utils import ResultCreationError
 
 
-class SamplingResult:
+class SamplingResult(dict):
     """
     Stores results data from a sampling experiment in the emulator. There is
     then a range of options for displaying the data, or alternatively the data
@@ -39,21 +39,15 @@ class SamplingResult:
     """
 
     def __init__(self, results: dict, input: State, **kwargs: Any) -> None:
+        super().__init__(results)
         if not isinstance(input, State):
             raise ResultCreationError("Input state should have type State.")
         self.__input = input
-        self.__dict = results
         self.__outputs = list(results.keys())
         # Store any additional provided data from kwargs as attributes
         for k in kwargs:
             setattr(self, k, kwargs[k])
-
         return
-
-    @property
-    def dictionary(self) -> dict:
-        """Stores the raw results dictionary generated in the experiment."""
-        return self.__dict
 
     @property
     def input(self) -> State:
@@ -69,38 +63,9 @@ class SamplingResult:
         """Custom get item behaviour - used when object accessed with []."""
         if not isinstance(item, State):
             raise TypeError("Get item value must be a State.")
-        if item not in self.dictionary:
+        if item not in self:
             raise KeyError("Provided output state not in data.")
-        return self.dictionary[item]
-
-    def __str__(self) -> str:
-        return str(self.dictionary)
-
-    def __len__(self) -> int:
-        return len(self.dictionary)
-
-    def __iter__(self) -> Iterator:
-        """Iterable to allow to do 'for output in SamplingResult'."""
-        yield from self.dictionary
-
-    def items(self) -> Iterable:
-        """
-        Returns dictionary items containing the output states and their
-        respective count numbers.
-        """
-        return self.dictionary.items()
-
-    def keys(self) -> Iterable:
-        """
-        Returns all output states contained in results.
-        """
-        return self.dictionary.keys()
-
-    def values(self) -> Iterable:
-        """
-        Returns all count values from the result.
-        """
-        return self.dictionary.values()
+        return super().__getitem__(item)
 
     def apply_threshold_mapping(self, invert: bool = False) -> "SamplingResult":
         """
@@ -119,7 +84,7 @@ class SamplingResult:
 
         """
         mapped_result: dict[State, float] = {}
-        for out_state, val in self.dictionary.items():
+        for out_state, val in self.items():
             new_s = State([1 if s >= 1 else 0 for s in out_state])
             if invert:
                 new_s = State([1 - s for s in new_s])
@@ -147,7 +112,7 @@ class SamplingResult:
 
         """
         mapped_result: dict[State, float] = {}
-        for out_state, val in self.dictionary.items():
+        for out_state, val in self.items():
             if invert:
                 new_s = State([1 - (s % 2) for s in out_state])
             else:
@@ -192,12 +157,11 @@ class SamplingResult:
             state_labels[state] = str(label)
 
         fig, ax = plt.subplots(figsize=(7, 6))
-        x_data = range(len(self.dictionary))
-        ax.bar(x_data, list(self.dictionary.values()))
+        x_data = range(len(self))
+        ax.bar(x_data, list(self.values()))
         ax.set_xticks(x_data)
         labels = [
-            state_labels[s] if s in state_labels else str(s)
-            for s in self.dictionary
+            state_labels[s] if s in state_labels else str(s) for s in self
         ]
         ax.set_xticklabels(labels, rotation=90)
         ax.set_xlabel("State")
@@ -215,7 +179,7 @@ class SamplingResult:
         compatible with all possible result types.
         """
         to_print = str(self.input) + " -> "
-        for ostate, p in self.dictionary.items():
+        for ostate, p in self.items():
             to_print += str(ostate) + " : " + str(p) + ", "
         to_print = to_print[:-2]
         print(to_print)  # noqa: T201
@@ -249,7 +213,7 @@ class SamplingResult:
         in_strings = [str(self.input)]
         out_strings = [str(s) for s in self.outputs]
         # Switch to probability if required
-        data = np.array(list(self.dictionary.values()))
+        data = np.array(list(self.values()))
         # Apply thresholding to values
         for i in range(data.shape[0]):
             val = data[i]

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -136,9 +136,9 @@ class SimulationResult(dict):
             if ostate is None:
                 return sub_r
             # Else return requested value
-            if ostate not in sub_r:
+            if ostate not in sub_r:  # type: ignore[operator]
                 raise KeyError("Requested output state not in data.")
-            return sub_r[ostate]
+            return sub_r[ostate]  # type: ignore[index]
         raise TypeError("Get item value must be either one or two States.")
 
     def apply_threshold_mapping(

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Iterator
+from typing import Any
 
 import matplotlib.figure
 import matplotlib.pyplot as plt
@@ -23,7 +23,7 @@ from ...sdk.state import State
 from ..utils import ResultCreationError
 
 
-class SimulationResult:
+class SimulationResult(dict):
     """
     Stores results data from a given simulation in the emulator. There is then
     a range of options for displaying the data, or alternatively the data can
@@ -78,7 +78,7 @@ class SimulationResult:
             for j, ostate in enumerate(self.__outputs):
                 input_results[ostate] = self.__array[i, j]
             dict_results[istate] = input_results
-        self.__dict = dict_results
+        super().__init__(dict_results)
 
         # Store any additional provided data from kwargs as attributes
         for k in kwargs:
@@ -105,11 +105,6 @@ class SimulationResult:
         return self.__outputs
 
     @property
-    def dictionary(self) -> dict:
-        """Stores a dictionary of inputs and the associated output values."""
-        return self.__dict
-
-    @property
     def result_type(self) -> str:
         """
         Details where the result is a probability or probability amplitude.
@@ -119,15 +114,9 @@ class SimulationResult:
     def __getitem__(self, item: State | tuple) -> float | dict:
         """Custom get item behaviour - used when object accessed with []."""
         if isinstance(item, State):
-            # When only one input is used, automatically return output value
-            # from dictionary instead of dictionary
-            if len(self.inputs) == 1:
-                if item not in self.dictionary[self.inputs[0]]:
-                    raise KeyError("Provided output state not in data.")
-                return self.dictionary[self.inputs[0]][item]
-            if item not in self.dictionary:
+            if item not in self:
                 raise KeyError("Provided input state not in data.")
-            return self.dictionary[item]
+            return super().__getitem__(item)
         if isinstance(item, tuple):
             # Check only two values have been provided
             if len(item) > 2:
@@ -136,14 +125,14 @@ class SimulationResult:
                 )
             # Separate data into two states
             istate = item[0]
-            ostate = item[1]
+            ostate = item[1] if len(item) == 2 else None
             # Check all aspects are valid
             if not isinstance(istate, State) or not isinstance(
                 ostate, (State, type(None))
             ):
                 raise TypeError("Get item values should have type State.")
-            if istate in self.dictionary:
-                sub_r = self.dictionary[istate]
+            if istate in self:
+                sub_r = super().__getitem__(istate)
             else:
                 raise KeyError("Requested input state not in data.")
             # If None provided as second value then return all results for input
@@ -154,13 +143,6 @@ class SimulationResult:
                 raise KeyError("Requested output state not in data.")
             return sub_r[ostate]
         raise TypeError("Get item value must be either one or two States.")
-
-    def __str__(self) -> str:
-        return str(self.dictionary)
-
-    def __iter__(self) -> Iterator:
-        """Iterable to allow to do 'for input in SimulationResult'."""
-        yield from self.dictionary
 
     def apply_threshold_mapping(
         self, invert: bool = False
@@ -186,9 +168,9 @@ class SimulationResult:
                 "amplitudes."
             )
         mapped_result: dict[State, dict] = {}
-        for in_state in self.inputs:
+        for in_state, results in self.items():
             mapped_result[in_state] = {}
-            for out_state, val in self.dictionary[in_state].items():
+            for out_state, val in results.items():
                 new_s = State([1 if s >= 1 else 0 for s in out_state])
                 if invert:
                     new_s = State([1 - s for s in new_s])
@@ -220,9 +202,9 @@ class SimulationResult:
                 "Parity mapping cannot be applied to probability amplitudes."
             )
         mapped_result: dict[State, dict] = {}
-        for in_state in self.inputs:
+        for in_state, results in self.items():
             mapped_result[in_state] = {}
-            for out_state, val in self.dictionary[in_state].items():
+            for out_state, val in results.items():
                 if invert:
                     new_s = State([1 - (s % 2) for s in out_state])
                 else:
@@ -313,9 +295,9 @@ class SimulationResult:
 
         """
         # Loop over each input and print results
-        for istate in self.inputs:
+        for istate, results in self.items():
             to_print = str(istate) + " -> "
-            for ostate, p in self.dictionary[istate].items():
+            for ostate, p in results.items():
                 # Adjust print order based on quantity
                 if self.result_type == "counts":
                     to_print += str(ostate) + " : " + str(p) + ", "
@@ -435,15 +417,16 @@ class SimulationResult:
         be used if there is a single input.
         """
         istate = self.inputs[0]
+        results = self[istate,]
         # Vary plot depending on result type
         if self.result_type != "probability_amplitude" or conv_to_probability:
             if self.result_type == "probability_amplitude":
                 d_data = {}
-                for s, p in self.dictionary[istate].items():
+                for s, p in results.items():
                     d_data[s] = abs(p) ** 2
                 title = "Probability"
             else:
-                d_data = self.dictionary[istate]
+                d_data = results
                 title = self.result_type.capitalize()
 
             fig, ax = plt.subplots(figsize=(7, 6))
@@ -460,14 +443,14 @@ class SimulationResult:
         # Plot both real and imaginary parts
         fig, axes = plt.subplots(1, 2, figsize=(14, 6))
         axes = np.array(axes)
-        x_data = range(len(self.dictionary[istate]))
-        axes[0].bar(x_data, np.real(list(self.dictionary[istate].values())))
-        axes[1].bar(x_data, np.imag(list(self.dictionary[istate].values())))
+        x_data = range(len(results))
+        axes[0].bar(x_data, np.real(list(results.values())))
+        axes[1].bar(x_data, np.imag(list(results.values())))
         for i in range(2):
             axes[i].set_xticks(x_data)
             labels = [
                 state_labels[s] if s in state_labels else str(s)
-                for s in self.dictionary[istate]
+                for s in results
             ]
             axes[i].set_xticklabels(labels, rotation=90)
             axes[i].set_xlabel("State")

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -115,7 +115,7 @@ class SimulationResult(dict):
         """Custom get item behaviour - used when object accessed with []."""
         if isinstance(item, State):
             if item not in self:
-                raise KeyError("Provided input state not in data.")
+                raise KeyError("Requested input state not in data.")
             return super().__getitem__(item)
         if isinstance(item, tuple):
             # Check only two values have been provided
@@ -131,10 +131,7 @@ class SimulationResult(dict):
                 ostate, (State, type(None))
             ):
                 raise TypeError("Get item values should have type State.")
-            if istate in self:
-                sub_r = super().__getitem__(istate)
-            else:
-                raise KeyError("Requested input state not in data.")
+            sub_r = self[istate]
             # If None provided as second value then return all results for input
             if ostate is None:
                 return sub_r

--- a/lightworks/emulator/results/simulation_result.py
+++ b/lightworks/emulator/results/simulation_result.py
@@ -417,7 +417,7 @@ class SimulationResult(dict):
         be used if there is a single input.
         """
         istate = self.inputs[0]
-        results = self[istate,]
+        results = dict(self[istate])  # type: ignore[arg-type]
         # Vary plot depending on result type
         if self.result_type != "probability_amplitude" or conv_to_probability:
             if self.result_type == "probability_amplitude":

--- a/tests/emulator/analyzer_test.py
+++ b/tests/emulator/analyzer_test.py
@@ -51,7 +51,7 @@ class TestAnalyzer:
         circuit = Circuit(2)
         circuit.bs(0)
         analyzer = Analyzer(circuit)
-        results = analyzer.analyze(State([1, 1]))
+        results = analyzer.analyze(State([1, 1]))[State([1, 1])]
         p = results[State([2, 0])]
         assert pytest.approx(p) == 0.5
 
@@ -68,20 +68,20 @@ class TestAnalyzer:
         circuit.bs(0)
         # And check output counts
         analyzer = Analyzer(circuit)
-        results = analyzer.analyze(State([1, 0, 0, 1]))
+        results = analyzer.analyze(State([1, 0, 0, 1]))[State([1, 0, 0, 1])]
         assert pytest.approx(abs(results[State([0, 1, 1, 0])])) == 0.5
 
     def test_analyzer_basic(self):
         """Check analyzer result with basic circuit."""
         analyzer = Analyzer(self.circuit)
-        results = analyzer.analyze(State([1, 0, 1, 0]))
+        results = analyzer.analyze(State([1, 0, 1, 0]))[State([1, 0, 1, 0])]
         p = results[State([0, 1, 0, 1])]
         assert pytest.approx(p, 1e-8) == 0.6331805740170607
 
     def test_analyzer_basic_2photons_in_mode(self):
         """Check analyzer result with basic circuit."""
         analyzer = Analyzer(self.circuit)
-        results = analyzer.analyze(State([2, 0, 0, 0]))
+        results = analyzer.analyze(State([2, 0, 0, 0]))[State([2, 0, 0, 0])]
         p = results[State([0, 1, 0, 1])]
         assert pytest.approx(p, 1e-8) == 0.0022854516590
 
@@ -92,12 +92,12 @@ class TestAnalyzer:
         analyzer = Analyzer(self.circuit)
         # Just heralding
         results = analyzer.analyze(State([1, 0, 1]))
-        p = results[State([0, 1, 1])]
+        p = results[State([1, 0, 1]), State([0, 1, 1])]
         assert pytest.approx(p, 1e-8) == 0.091713377373246
         # Heralding + post-selection
         analyzer.post_selection = lambda s: s[0] == 1
         results = analyzer.analyze(State([1, 0, 1]))
-        p = results[State([1, 1, 0])]
+        p = results[State([1, 0, 1]), State([1, 1, 0])]
         assert pytest.approx(p, 1e-8) == 0.002934140618653
         # Check performance metric
         assert pytest.approx(results.performance, 1e-8) == 0.03181835438235
@@ -112,14 +112,14 @@ class TestAnalyzer:
         analyzer = Analyzer(self.lossy_circuit)
         # Just heralding
         results = analyzer.analyze(State([1, 0, 1]))
-        p = results[State([0, 1, 0])]
+        p = results[State([1, 0, 1]), State([0, 1, 0])]
         assert pytest.approx(p, 1e-8) == 0.062204471804458
         # Heralding + post-selection
         analyzer.post_selection = lambda s: s[0] == 0
         results = analyzer.analyze(State([1, 0, 1]))
-        p = results[State([0, 0, 1])]
+        p = results[State([1, 0, 1]), State([0, 0, 1])]
         assert pytest.approx(p, 1e-8) == 0.0202286624257920
-        p = results[State([0, 0, 0])]
+        p = results[State([1, 0, 1]), State([0, 0, 0])]
         assert pytest.approx(p, 1e-8) == 0.6051457174354371
         # Check performance metric
         assert pytest.approx(results.performance, 1e-8) == 0.6893563871958014
@@ -139,14 +139,14 @@ class TestAnalyzer:
         analyzer = Analyzer(new_circ)
         # Just heralding
         results = analyzer.analyze(State([1, 0, 1]))
-        p = results[State([0, 1, 0])]
+        p = results[State([1, 0, 1]), State([0, 1, 0])]
         assert pytest.approx(p, 1e-8) == 0.062204471804458
         # Heralding + post-selection
         analyzer.post_selection = lambda s: s[0] == 0
         results = analyzer.analyze(State([1, 0, 1]))
-        p = results[State([0, 0, 1])]
+        p = results[State([1, 0, 1]), State([0, 0, 1])]
         assert pytest.approx(p, 1e-8) == 0.0202286624257920
-        p = results[State([0, 0, 0])]
+        p = results[State([1, 0, 1]), State([0, 0, 0])]
         assert pytest.approx(p, 1e-8) == 0.6051457174354371
         # Check performance metric
         assert pytest.approx(results.performance, 1e-8) == 0.6893563871958014
@@ -170,11 +170,11 @@ class TestAnalyzer:
         analyzer = Analyzer(circuit)
         analyzer.post_selection = lambda s: s[0] == 1
         results = analyzer.analyze(State([1, 0, 1, 0]))
-        p = results[State([1, 1, 0, 0])]
+        p = results[State([1, 0, 1, 0]), State([1, 1, 0, 0])]
         # Update circuit and get results
         circuit.bs(0)
         results = analyzer.analyze(State([1, 0, 1, 0]))
-        p2 = results[State([1, 1, 0, 0])]
+        p2 = results[State([1, 0, 1, 0]), State([1, 1, 0, 0])]
         assert p != p2
 
     def test_analyzer_circuit_parameter_update(self):
@@ -193,11 +193,11 @@ class TestAnalyzer:
         post_select.add(0, 1)
         analyzer.post_selection = post_select
         results = analyzer.analyze(State([1, 0, 1, 0]))
-        p = results[State([1, 1, 0, 0])]
+        p = results[State([1, 0, 1, 0]), State([1, 1, 0, 0])]
         # Update parameter and get results
         param.set(0.65)
         results = analyzer.analyze(State([1, 0, 1, 0]))
-        p2 = results[State([1, 1, 0, 0])]
+        p2 = results[State([1, 0, 1, 0]), State([1, 1, 0, 0])]
         assert p != p2
 
     def test_circuit_assignment(self):

--- a/tests/emulator/result_test.py
+++ b/tests/emulator/result_test.py
@@ -141,7 +141,7 @@ class TestSamplingResult:
         results dictionary
         """
         r = SamplingResult(self.test_dict, self.test_input)
-        assert str(r) == str(r.dictionary)
+        assert str(r) == str(self.test_dict)
 
     def test_get_items(self):
         """
@@ -224,7 +224,7 @@ class TestSimulationResult:
             inputs=self.test_single_inputs,
             outputs=self.test_single_outputs,
         )
-        assert r[State([1, 0, 1, 0])] == 0.3
+        assert r[self.test_single_inputs[0]][State([1, 0, 1, 0])] == 0.3
 
     def test_multi_input_retrival(self):
         """
@@ -389,7 +389,7 @@ class TestSimulationResult:
             outputs=self.test_single_outputs,
         )
         new_r = r.apply_parity_mapping()
-        assert new_r.dictionary == {
+        assert new_r == {
             State([1, 1, 0, 0]): {
                 State([1, 0, 1, 0]): 0.4,
                 State([0, 1, 0, 1]): 0.2,
@@ -408,7 +408,7 @@ class TestSimulationResult:
             outputs=self.test_multi_outputs,
         )
         new_r = r.apply_parity_mapping()
-        assert new_r.dictionary == {
+        assert new_r == {
             State([1, 1, 0, 0]): {
                 State([1, 0, 1, 0]): 0.4,
                 State([0, 1, 0, 1]): 0.2,
@@ -431,7 +431,7 @@ class TestSimulationResult:
             outputs=self.test_single_outputs,
         )
         new_r = r.apply_threshold_mapping()
-        assert new_r.dictionary == {
+        assert new_r == {
             State([1, 1, 0, 0]): {
                 State([1, 0, 1, 0]): 0.4,
                 State([0, 1, 0, 1]): 0.2,
@@ -450,7 +450,7 @@ class TestSimulationResult:
             outputs=self.test_multi_outputs,
         )
         new_r = r.apply_threshold_mapping()
-        assert new_r.dictionary == {
+        assert new_r == {
             State([1, 1, 0, 0]): {
                 State([1, 0, 1, 0]): 0.4,
                 State([0, 1, 0, 1]): 0.2,

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -46,7 +46,7 @@ class TestSamplerGeneral:
         sampler = Sampler(circuit, State([1, 0, 1, 0]))
         results = sampler.sample_N_inputs(5000, seed=1)
         results2 = sampler.sample_N_inputs(5000, seed=1)
-        assert results.dictionary == results2.dictionary
+        assert results == results2
 
     def test_sample_n_states_seed_detector(self):
         """
@@ -61,7 +61,7 @@ class TestSamplerGeneral:
         )
         results = sampler.sample_N_inputs(5000, seed=1)
         results2 = sampler.sample_N_inputs(5000, seed=1)
-        assert results.dictionary == results2.dictionary
+        assert results == results2
 
     def test_circuit_update_with_sampler(self):
         """

--- a/tests/emulator/simulator_test.py
+++ b/tests/emulator/simulator_test.py
@@ -96,7 +96,7 @@ class TestSimulator:
         unitary = Unitary(unitary)
         sim = Simulator(unitary)
         results = sim.simulate(State([1, 0, 1, 0]))
-        x = results[State([0, 2, 0, 0])]
+        x = results[State([1, 0, 1, 0]), State([0, 2, 0, 0])]
         assert x == pytest.approx(
             -0.18218877232689196 - 0.266230290128261j, 1e-8
         )
@@ -273,7 +273,10 @@ class TestSimulator:
         # Then check equivalence of results for all outputs
         for output in results_h.outputs:
             full_state = output[0:2] + State([0, 1]) + output[2:]
-            assert pytest.approx(results_h[output]) == results[full_state]
+            assert (
+                pytest.approx(results_h[State([0, 1, 1, 0]), output])
+                == results[State([0, 1, 0, 1, 1, 0]), full_state]
+            )
 
     def test_herald_not_herald_equivalance_lossy(self):
         """
@@ -299,7 +302,10 @@ class TestSimulator:
         # Then check equivalence of results for all outputs
         for output in results_h.outputs:
             full_state = output[0:2] + State([0, 1]) + output[2:]
-            assert pytest.approx(results_h[output]) == results[full_state]
+            assert (
+                pytest.approx(results_h[State([0, 1, 1, 0]), output])
+                == results[State([0, 1, 0, 1, 1, 0]), full_state]
+            )
 
     def test_herald_not_herald_equivalance_grouped(self):
         """
@@ -328,4 +334,7 @@ class TestSimulator:
         # Then check equivalence of results for all outputs
         for output in results_h.outputs:
             full_state = output[0:2] + State([0, 1]) + output[2:]
-            assert pytest.approx(results_h[output]) == results[full_state]
+            assert (
+                pytest.approx(results_h[State([0, 1, 1, 0]), output])
+                == results[State([0, 1, 0, 1, 1, 0]), full_state]
+            )

--- a/tests/qubit/gate_test.py
+++ b/tests/qubit/gate_test.py
@@ -38,11 +38,11 @@ class TestSingleQubitGates:
         """Checks that the output from the I gate is correct."""
         sim = Simulator(I())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1
         assert pytest.approx(results[State([0, 1])], 1e-6) == 0
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 0
         assert pytest.approx(results[State([0, 1])], 1e-6) == 1
 
@@ -50,11 +50,11 @@ class TestSingleQubitGates:
         """Checks that the output from the Hadamard gate is correct."""
         sim = Simulator(H())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 2**-0.5
         assert pytest.approx(results[State([0, 1])], 1e-6) == 2**-0.5
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 2**-0.5
         assert pytest.approx(results[State([0, 1])], 1e-6) == -(2**-0.5)
 
@@ -62,11 +62,11 @@ class TestSingleQubitGates:
         """Checks that the output from the X gate is correct."""
         sim = Simulator(X())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 0
         assert pytest.approx(results[State([0, 1])], 1e-6) == 1
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1
         assert pytest.approx(results[State([0, 1])], 1e-6) == 0
 
@@ -74,11 +74,11 @@ class TestSingleQubitGates:
         """Checks that the output from the Y gate is correct."""
         sim = Simulator(Y())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 0
         assert pytest.approx(results[State([0, 1])], 1e-6) == 1j
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == -1j
         assert pytest.approx(results[State([0, 1])], 1e-6) == 0
 
@@ -86,11 +86,11 @@ class TestSingleQubitGates:
         """Checks that the output from the Z gate is correct."""
         sim = Simulator(Z())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1
         assert pytest.approx(results[State([0, 1])], 1e-6) == 0
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 0
         assert pytest.approx(results[State([0, 1])], 1e-6) == -1
 
@@ -98,11 +98,11 @@ class TestSingleQubitGates:
         """Checks that the output from the S gate is correct."""
         sim = Simulator(S())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1
         assert pytest.approx(results[State([0, 1])], 1e-6) == 0
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 0
         assert pytest.approx(results[State([0, 1])], 1e-6) == 1j
 
@@ -114,11 +114,11 @@ class TestSingleQubitGates:
         """Checks that the output from the T gate is correct."""
         sim = Simulator(T())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1
         assert pytest.approx(results[State([0, 1])], 1e-6) == 0
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 0
         assert pytest.approx(results[State([0, 1])], 1e-6) == np.exp(
             1j * np.pi / 4
@@ -132,11 +132,11 @@ class TestSingleQubitGates:
         """Checks that the output from the SX gate is correct."""
         sim = Simulator(SX())
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1 / 2 * (1 + 1j)
         assert pytest.approx(results[State([0, 1])], 1e-6) == 1 / 2 * (1 - 1j)
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1 / 2 * (1 - 1j)
         assert pytest.approx(results[State([0, 1])], 1e-6) == 1 / 2 * (1 + 1j)
 
@@ -145,11 +145,11 @@ class TestSingleQubitGates:
         phase = 6.28 * random()
         sim = Simulator(P(phase))
         # Input |1,0>
-        results = sim.simulate(State([1, 0]))
+        results = sim.simulate(State([1, 0]))[State([1, 0])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 1
         assert pytest.approx(results[State([0, 1])], 1e-6) == 0
         # Input |0,1>
-        results = sim.simulate(State([0, 1]))
+        results = sim.simulate(State([0, 1]))[State([0, 1])]
         assert pytest.approx(results[State([1, 0])], 1e-6) == 0
         assert pytest.approx(results[State([0, 1])], 1e-6) == np.exp(1j * phase)
 


### PR DESCRIPTION
# Summary

Changed result to be a subclass of dictionary, enabling utilisation of the existing methods provide by this object. Also modified the behaviour of `SimulationResult` such that the first state provided will always be used to reference the input state, even in the case of a single input. This is a breaking change.

## Full list of changes

- Changed result objects to be a subclass of dict and removed not redundant methods.
- Modified indexing behaviour of SimulationResult in instances where a single input is contained within the result. Previously in these cases the first index would be used for the output, but it now always corresponds to the input. While the previous version was slightly more convenient, the inconsistency could be confusing for users.
- Updated docs to reflect changes and corrected in a few places.
