### PR TITLE
Mypy disallow generics

### DIFF
--- a/lightworks/emulator/backends/abc_backend.py
+++ b/lightworks/emulator/backends/abc_backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABCMeta, abstractmethod
+from typing import Any
 
 from ...sdk.tasks import TaskData
 from .caching import CacheData, check_parameter_updates, get_calculation_values
@@ -30,7 +31,7 @@ class BackendABC(metaclass=ABCMeta):
     @abstractmethod
     def name(self) -> str: ...
 
-    def _check_cache(self, data: TaskData) -> dict | None:
+    def _check_cache(self, data: TaskData) -> dict[str, Any] | None:
         name = data.__class__.__name__
         if hasattr(self, "_cache") and name in self._cache:
             old_values = self._cache[name].values
@@ -40,7 +41,7 @@ class BackendABC(metaclass=ABCMeta):
         # Return false if cache doesn't exist or name not found
         return None
 
-    def _add_to_cache(self, data: TaskData, results: dict) -> None:
+    def _add_to_cache(self, data: TaskData, results: dict[str, Any]) -> None:
         if not hasattr(self, "_cache"):
             self._cache = {}
         name = data.__class__.__name__

--- a/lightworks/emulator/backends/backend.py
+++ b/lightworks/emulator/backends/backend.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from typing import Any
+
 from ...sdk.tasks import Task
 from ..utils import BackendError
 from .permanent import PermanentBackend
@@ -35,7 +37,7 @@ class Backend:
 
         return
 
-    def run(self, task: "Task") -> dict:
+    def run(self, task: "Task") -> dict[Any, Any]:
         """
         Runs the provided task on the current backend.
 

--- a/lightworks/emulator/backends/caching.py
+++ b/lightworks/emulator/backends/caching.py
@@ -39,7 +39,7 @@ class CacheData:
     """
 
     values: list[Any]
-    results: dict
+    results: dict[Any, Any]
 
 
 def check_parameter_updates(values1: list[Any], values2: list[Any]) -> bool:

--- a/lightworks/emulator/backends/fock_backend.py
+++ b/lightworks/emulator/backends/fock_backend.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 from multimethod import multimethod
+from numpy.typing import NDArray
 
 from ...sdk.circuit.photonic_compiler import CompiledPhotonicCircuit
 from ...sdk.results import (
@@ -82,7 +83,7 @@ class FockBackend(BackendABC):
 
     def probability_amplitude(
         self,
-        unitary: np.ndarray,
+        unitary: NDArray[np.complex128],
         input_state: list[int],
         output_state: list[int],
     ) -> complex:
@@ -92,7 +93,7 @@ class FockBackend(BackendABC):
 
     def probability(
         self,
-        unitary: np.ndarray,
+        unitary: NDArray[np.complex128],
         input_state: list[int],
         output_state: list[int],
     ) -> float:
@@ -102,7 +103,7 @@ class FockBackend(BackendABC):
 
     def full_probability_distribution(
         self, circuit: CompiledPhotonicCircuit, input_state: State
-    ) -> dict:
+    ) -> dict[State, float]:
         raise BackendError(
             "Current backend does not implement full_probability_distribution "
             "method."

--- a/lightworks/emulator/backends/permanent.py
+++ b/lightworks/emulator/backends/permanent.py
@@ -16,6 +16,7 @@
 from math import factorial, prod
 
 import numpy as np
+from numpy.typing import NDArray
 from thewalrus import perm
 
 from ...__settings import settings
@@ -38,7 +39,7 @@ class PermanentBackend(FockBackend):
 
     def probability_amplitude(
         self,
-        unitary: np.ndarray,
+        unitary: NDArray[np.complex128],
         input_state: list[int],
         output_state: list[int],
     ) -> complex:
@@ -75,7 +76,7 @@ class PermanentBackend(FockBackend):
 
     def probability(
         self,
-        unitary: np.ndarray,
+        unitary: NDArray[np.complex128],
         input_state: list[int],
         output_state: list[int],
     ) -> float:
@@ -111,7 +112,7 @@ class PermanentBackend(FockBackend):
 
     def full_probability_distribution(
         self, circuit: CompiledPhotonicCircuit, input_state: State
-    ) -> dict:
+    ) -> dict[State, float]:
         """
         Finds the output probability distribution for the provided circuit and
         input state.
@@ -165,8 +166,8 @@ class PermanentBackend(FockBackend):
 
 
 def partition(
-    unitary: np.ndarray, in_state: list[int], out_state: list[int]
-) -> np.ndarray:
+    unitary: NDArray[np.complex128], in_state: list[int], out_state: list[int]
+) -> NDArray[np.complex128]:
     """
     Converts the unitary matrix into a larger matrix used for in the
     permanent calculation.

--- a/lightworks/emulator/backends/permanent.py
+++ b/lightworks/emulator/backends/permanent.py
@@ -152,11 +152,11 @@ class PermanentBackend(FockBackend):
             p = self.probability(circuit.U_full, input_state.s, ostate)
             if p > settings.sampler_probability_threshold:
                 # Only care about non-loss modes
-                ostate = State(ostate[: circuit.n_modes])  # noqa: PLW2901
-                if ostate in pdist:
-                    pdist[ostate] += p
+                meas_state = State(ostate[: circuit.n_modes])
+                if meas_state in pdist:
+                    pdist[meas_state] += p
                 else:
-                    pdist[ostate] = p
+                    pdist[meas_state] = p
         # Work out zero photon component before saving to unique results
         total_prob = sum(pdist.values())
         if total_prob < 1 and circuit.loss_modes > 0:

--- a/lightworks/emulator/simulation/analyzer.py
+++ b/lightworks/emulator/simulation/analyzer.py
@@ -15,6 +15,7 @@
 from collections.abc import Callable
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ...sdk.results import SimulationResult
 from ...sdk.state import State
@@ -43,7 +44,11 @@ class AnalyzerRunner(RunnerABC):
     """
 
     def __init__(
-        self, data: AnalyzerTask, probability_function: Callable
+        self,
+        data: AnalyzerTask,
+        probability_function: Callable[
+            [NDArray[np.complex128], list[int], list[int]], float
+        ],
     ) -> None:
         self.data = data
         self.func = probability_function
@@ -109,7 +114,7 @@ class AnalyzerRunner(RunnerABC):
 
     def _get_probs(
         self, full_inputs: list[list[int]], full_outputs: list[list[int]]
-    ) -> np.ndarray:
+    ) -> NDArray[np.float64]:
         """
         Create an array of output probabilities for a given set of inputs and
         outputs.
@@ -156,7 +161,7 @@ class AnalyzerRunner(RunnerABC):
 
     def _calculate_error_rate(
         self,
-        probabilities: np.ndarray,
+        probabilities: NDArray[np.float64],
         inputs: list[State],
         outputs: list[State],
         expected: dict[State, State | list[State]],

--- a/lightworks/emulator/simulation/probability_distribution.py
+++ b/lightworks/emulator/simulation/probability_distribution.py
@@ -26,7 +26,9 @@ from ..state import AnnotatedState
 def pdist_calc(
     circuit: CompiledPhotonicCircuit,
     inputs: dict[State, int | float],
-    probability_func: Callable,
+    probability_func: Callable[
+        [CompiledPhotonicCircuit, State], dict[State, float]
+    ],
 ) -> dict[State, float]:
     """
     Calculate the output state probability distribution for cases where
@@ -77,7 +79,9 @@ def pdist_calc(
 def annotated_state_pdist_calc(
     circuit: CompiledPhotonicCircuit,
     inputs: dict[AnnotatedState, int | float],
-    probability_func: Callable,
+    probability_func: Callable[
+        [CompiledPhotonicCircuit, State], dict[State, float]
+    ],
 ) -> dict[State, float]:
     """
     Perform output state probability distribution calculation using complex
@@ -101,7 +105,7 @@ def annotated_state_pdist_calc(
     """
     # Determine the input state combinations given the labels
     unique_inputs: set[State] = set()
-    input_combinations: dict[AnnotatedState, list] = {}
+    input_combinations: dict[AnnotatedState, list[State]] = {}
     for state in inputs:
         # Find all labels in a given state
         all_labels = []

--- a/lightworks/emulator/simulation/runner.py
+++ b/lightworks/emulator/simulation/runner.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABCMeta, abstractmethod
+from typing import Any
 
 
 class RunnerABC(metaclass=ABCMeta):
@@ -21,4 +22,4 @@ class RunnerABC(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def run(self) -> dict: ...  # noqa: D102
+    def run(self) -> dict[Any, Any]: ...  # noqa: D102

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 
 import numpy as np
 
+from ...sdk.circuit.photonic_compiler import CompiledPhotonicCircuit
 from ...sdk.results import SamplingResult
 from ...sdk.state import State
 from ...sdk.tasks import SamplerTask
@@ -57,7 +58,13 @@ class SamplerRunner(RunnerABC):
 
     """
 
-    def __init__(self, data: SamplerTask, pdist_function: Callable) -> None:
+    def __init__(
+        self,
+        data: SamplerTask,
+        pdist_function: Callable[
+            [CompiledPhotonicCircuit, State], dict[State, float]
+        ],
+    ) -> None:
         self.data = data
         self.source = Source() if self.data.source is None else self.data.source
         self.detector = (
@@ -65,7 +72,7 @@ class SamplerRunner(RunnerABC):
         )
         self.func = pdist_function
 
-    def distribution_calculator(self) -> dict:
+    def distribution_calculator(self) -> dict[State, float]:
         """
         Calculates the output probability distribution for the provided
         configuration. This needs to be done before sampling.

--- a/lightworks/emulator/simulation/simulator.py
+++ b/lightworks/emulator/simulation/simulator.py
@@ -15,6 +15,7 @@
 from collections.abc import Callable
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ...sdk.results import SimulationResult
 from ...sdk.state import State
@@ -39,7 +40,11 @@ class SimulatorRunner(RunnerABC):
     """
 
     def __init__(
-        self, data: SimulatorTask, amplitude_function: Callable
+        self,
+        data: SimulatorTask,
+        amplitude_function: Callable[
+            [NDArray[np.complex128], list[int], list[int]], complex
+        ],
     ) -> None:
         self.data = data
         self.func = amplitude_function

--- a/lightworks/emulator/simulation/simulator.py
+++ b/lightworks/emulator/simulation/simulator.py
@@ -63,10 +63,12 @@ class SimulatorRunner(RunnerABC):
         """
         if self.data.outputs is None:
             check_photon_numbers(self.data.inputs)
-            outputs = fock_basis(
-                self.data.circuit.input_modes, self.data.inputs[0].n_photons
-            )
-            outputs = [State(s) for s in outputs]
+            outputs = [
+                State(s)
+                for s in fock_basis(
+                    self.data.circuit.input_modes, self.data.inputs[0].n_photons
+                )
+            ]
         else:
             check_photon_numbers(self.data.inputs + self.data.outputs)
             outputs = self.data.outputs

--- a/lightworks/emulator/state/annotated_state.py
+++ b/lightworks/emulator/state/annotated_state.py
@@ -110,18 +110,18 @@ class AnnotatedState:
             "AnnotatedState object does not support item assignment."
         )
 
-    def __iter__(self) -> Iterator[list]:
+    def __iter__(self) -> Iterator[list[int]]:
         yield from self.s
 
     @overload
-    def __getitem__(self, indices: int) -> list: ...
+    def __getitem__(self, indices: int) -> list[int]: ...
 
     @overload
     def __getitem__(self, indices: slice) -> "AnnotatedState": ...
 
     def __getitem__(
         self, indices: int | slice
-    ) -> Union["AnnotatedState", list]:
+    ) -> Union["AnnotatedState", list[int]]:
         if isinstance(indices, slice):
             return AnnotatedState(self.__s[indices])
         if isinstance(indices, int):

--- a/lightworks/emulator/utils/state_utils.py
+++ b/lightworks/emulator/utils/state_utils.py
@@ -19,12 +19,12 @@ Script to store various useful functions for the simulation aspect of the code.
 from collections.abc import Iterable
 
 
-def fock_basis(N: int, n: int) -> list:  # noqa: N803
+def fock_basis(N: int, n: int) -> list[list[int]]:  # noqa: N803
     """Returns the Fock basis for n photons in N modes."""
     return list(_sums(N, n))
 
 
-def _sums(length: int, total_sum: int) -> Iterable:
+def _sums(length: int, total_sum: int) -> Iterable[list[int]]:
     if length == 1:
         yield [
             total_sum,
@@ -35,7 +35,7 @@ def _sums(length: int, total_sum: int) -> Iterable:
                 yield [*permutation, value]
 
 
-def annotated_state_to_string(state: list) -> str:
+def annotated_state_to_string(state: list[list[int]]) -> str:
     """Converts the provided annotated state to a string with ket notation."""
     string = "|"
     for s in state:

--- a/lightworks/interferometers/decomposition.py
+++ b/lightworks/interferometers/decomposition.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..sdk.utils import DecompositionUnsuccessful, check_unitary
 
 
-def reck_decomposition(unitary: np.ndarray) -> tuple[dict[str, float], list]:
+def reck_decomposition(
+    unitary: NDArray[np.complex128],
+) -> tuple[dict[str, float], list[float]]:
     """
     Performs the triangular decomposition procedure for a provided unitary
     matrix.
@@ -77,7 +80,7 @@ def reck_decomposition(unitary: np.ndarray) -> tuple[dict[str, float], list]:
 
 def bs_matrix(
     mode1: int, mode2: int, theta: float, phi: float, n_modes: int
-) -> np.ndarray:
+) -> NDArray[np.complex128]:
     """
     Generates a n_modes X n_modes matrix which implements the beam
     transformation of the unit cell between two modes.
@@ -91,7 +94,7 @@ def bs_matrix(
     return mat
 
 
-def check_null(mat: np.ndarray, precision: float = 1e-10) -> bool:
+def check_null(mat: NDArray[np.complex128], precision: float = 1e-10) -> bool:
     """
     A function to check if a provided matrix has been nulled correctly by
     the algorithm.

--- a/lightworks/qubit/converter/qiskit_convert.py
+++ b/lightworks/qubit/converter/qiskit_convert.py
@@ -275,7 +275,7 @@ class QiskitConverter:
 
 def convert_two_qubits_to_adjacent(
     q0: int, q1: int
-) -> tuple[int, int, list[tuple]]:
+) -> tuple[int, int, list[tuple[int, int]]]:
     """
     Takes two qubit indices and converts these so that they are adjacent to each
     other, and determining the swaps required for this. The order of the two

--- a/lightworks/qubit/gates/single_qubit_gates.py
+++ b/lightworks/qubit/gates/single_qubit_gates.py
@@ -41,7 +41,7 @@ class H(Unitary):
     """
 
     def __init__(self) -> None:
-        unitary = np.array([[1, 1], [1, -1]]) / 2**0.5
+        unitary = np.array([[1, 1], [1, -1]], dtype=np.complex128) / 2**0.5
         super().__init__(unitary, "H")
 
 
@@ -129,7 +129,9 @@ class SX(Unitary):
     """
 
     def __init__(self) -> None:
-        unitary = 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]])
+        unitary = 0.5 * np.array(
+            [[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]], dtype=np.complex128
+        )
         super().__init__(unitary, "SX")
 
 

--- a/lightworks/qubit/gates/two_qubit_gates.py
+++ b/lightworks/qubit/gates/two_qubit_gates.py
@@ -188,7 +188,9 @@ class SWAP(PhotonicCircuit):
 
     """
 
-    def __init__(self, qubit_1: tuple, qubit_2: tuple) -> None:
+    def __init__(
+        self, qubit_1: tuple[int, int], qubit_2: tuple[int, int]
+    ) -> None:
         # Confirm supplied form is correct
         if len(qubit_1) != 2:
             raise ValueError(

--- a/lightworks/sdk/circuit/parameters.py
+++ b/lightworks/sdk/circuit/parameters.py
@@ -213,7 +213,7 @@ class ParameterDict:
         # If any parameters has bounds return True, else return False
         return any(v.has_bounds() for v in self.__pdict.values())
 
-    def keys(self) -> Iterable:
+    def keys(self) -> Iterable[str]:
         """Returns all keys associated with the Parameters as an iterable."""
         return self.__pdict.keys()
 

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Union
 import matplotlib.pyplot as plt
 import numpy as np
 from IPython import display
+from numpy.typing import NDArray
 
 from ..utils import (
     CircuitCompilationError,
@@ -106,7 +107,7 @@ class PhotonicCircuit:
         return f"lightworks.PhotonicCircuit({self.n_modes})"
 
     @property
-    def U(self) -> np.ndarray:  # noqa: N802
+    def U(self) -> NDArray[np.complex128]:  # noqa: N802
         """
         The effective unitary that the circuit implements across modes. This
         will include the effect of any loss within a circuit. It is calculated
@@ -115,7 +116,7 @@ class PhotonicCircuit:
         return self._build().U_full[: self.n_modes, : self.n_modes]
 
     @property
-    def U_full(self) -> np.ndarray:  # noqa: N802
+    def U_full(self) -> NDArray[np.complex128]:  # noqa: N802
         """
         The full unitary for the created circuit, this will include the
         additional modes used for the simulation of loss, if this has been

--- a/lightworks/sdk/circuit/photonic_compiler.py
+++ b/lightworks/sdk/circuit/photonic_compiler.py
@@ -15,6 +15,7 @@
 from copy import copy
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..utils import ModeRangeError
 from .photonic_components import Barrier, Component, Group, Loss
@@ -55,7 +56,7 @@ class CompiledPhotonicCircuit:
         return self.n_modes + self.loss_modes
 
     @property
-    def U_full(self) -> np.ndarray:  # noqa: N802
+    def U_full(self) -> NDArray[np.complex128]:  # noqa: N802
         """Full unitary matrix."""
         return self._unitary
 

--- a/lightworks/sdk/circuit/photonic_components.py
+++ b/lightworks/sdk/circuit/photonic_components.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, fields
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..utils import check_unitary, permutation_mat_from_swaps_dict
 from .parameters import Parameter
@@ -29,7 +30,7 @@ class Component(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def get_unitary(self, n_modes: int) -> np.ndarray:
+    def get_unitary(self, n_modes: int) -> NDArray[np.complex128]:
         """
         Returns a unitary matrix corresponding to the transformation implemented
         by the component with size n_modes.
@@ -83,7 +84,7 @@ class BeamSplitter(Component):
             return self.reflectivity.get()
         return self.reflectivity
 
-    def get_unitary(self, n_modes: int) -> np.ndarray:  # noqa: D102
+    def get_unitary(self, n_modes: int) -> NDArray[np.complex128]:  # noqa: D102
         self.validate()
         theta = np.arccos(self._reflectivity**0.5)
         unitary = np.identity(n_modes, dtype=complex)
@@ -115,7 +116,7 @@ class PhaseShifter(Component):
             return self.phi.get()
         return self.phi
 
-    def get_unitary(self, n_modes: int) -> np.ndarray:  # noqa: D102
+    def get_unitary(self, n_modes: int) -> NDArray[np.complex128]:  # noqa: D102
         unitary = np.identity(n_modes, dtype=complex)
         unitary[self.mode, self.mode] = np.exp(1j * self._phi)
         return unitary
@@ -144,7 +145,7 @@ class Loss(Component):
             return self.loss.get()
         return self.loss
 
-    def get_unitary(self, n_modes: int) -> np.ndarray:  # noqa: D102
+    def get_unitary(self, n_modes: int) -> NDArray[np.complex128]:  # noqa: D102
         self.validate()
         transmission = 1 - self._loss
         # Assumes loss mode to use is last mode in circuit
@@ -164,7 +165,7 @@ class Barrier(Component):
 
     modes: list[int]
 
-    def get_unitary(self, n_modes: int) -> np.ndarray:  # noqa: D102
+    def get_unitary(self, n_modes: int) -> NDArray[np.complex128]:  # noqa: D102
         return np.identity(n_modes, dtype=complex)
 
 
@@ -186,7 +187,7 @@ class ModeSwaps(Component):
                 "contain the same modes."
             )
 
-    def get_unitary(self, n_modes: int) -> np.ndarray:  # noqa: D102
+    def get_unitary(self, n_modes: int) -> NDArray[np.complex128]:  # noqa: D102
         return permutation_mat_from_swaps_dict(self.swaps, n_modes)
 
 
@@ -213,7 +214,7 @@ class UnitaryMatrix(Component):
     """
 
     mode: int
-    unitary: np.ndarray
+    unitary: NDArray[np.complex128]
     label: str
 
     def __post_init__(self) -> None:
@@ -230,7 +231,7 @@ class UnitaryMatrix(Component):
         if not isinstance(self.label, str):
             raise TypeError("Label for unitary should be a string.")
 
-    def get_unitary(self, n_modes: int) -> np.ndarray:  # noqa: D102
+    def get_unitary(self, n_modes: int) -> NDArray[np.complex128]:  # noqa: D102
         unitary = np.identity(n_modes, dtype=complex)
         nm = self.unitary.shape[0]
         unitary[self.mode : self.mode + nm, self.mode : self.mode + nm] = (

--- a/lightworks/sdk/circuit/unitary.py
+++ b/lightworks/sdk/circuit/unitary.py
@@ -17,6 +17,7 @@ Dedicated unitary component for implementing unitary matrices on a circuit.
 """
 
 import numpy as np
+from numpy.typing import NDArray
 
 from .photonic_circuit import PhotonicCircuit
 from .photonic_components import UnitaryMatrix
@@ -34,7 +35,9 @@ class Unitary(PhotonicCircuit):
 
     """
 
-    def __init__(self, unitary: np.ndarray, label: str = "U") -> None:
+    def __init__(
+        self, unitary: NDArray[np.complex128], label: str = "U"
+    ) -> None:
         unitary = np.array(unitary)
         super().__init__(int(unitary.shape[0]))
         self._PhotonicCircuit__circuit_spec = [UnitaryMatrix(0, unitary, label)]

--- a/lightworks/sdk/results/probability_distribution.py
+++ b/lightworks/sdk/results/probability_distribution.py
@@ -16,7 +16,7 @@ from ..state import State
 from ..utils import ProbabilityDistributionError
 
 
-class ProbabilityDistribution(dict):
+class ProbabilityDistribution(dict[State, float]):
     """
     Stores a created ProbabilityDistribution and prevents modification to
     values.

--- a/lightworks/sdk/results/sampling_result.py
+++ b/lightworks/sdk/results/sampling_result.py
@@ -23,7 +23,7 @@ from ..state import State
 from ..utils import ResultCreationError
 
 
-class SamplingResult(dict):
+class SamplingResult(dict[State, int]):
     """
     Stores results data from a sampling experiment in the emulator. There is
     then a range of options for displaying the data, or alternatively the data
@@ -38,7 +38,9 @@ class SamplingResult(dict):
 
     """
 
-    def __init__(self, results: dict, input: State, **kwargs: Any) -> None:
+    def __init__(
+        self, results: dict[State, int], input: State, **kwargs: Any
+    ) -> None:
         super().__init__(results)
         if not isinstance(input, State):
             raise ResultCreationError("Input state should have type State.")
@@ -59,7 +61,7 @@ class SamplingResult(dict):
         """All outputs measured in the sampling experiment."""
         return self.__outputs
 
-    def __getitem__(self, item: State) -> float | dict:
+    def __getitem__(self, item: State) -> int:
         """Custom get item behaviour - used when object accessed with []."""
         if not isinstance(item, State):
             raise TypeError("Get item value must be a State.")
@@ -83,7 +85,7 @@ class SamplingResult(dict):
                 distribution.
 
         """
-        mapped_result: dict[State, float] = {}
+        mapped_result: dict[State, int] = {}
         for out_state, val in self.items():
             new_s = State([1 if s >= 1 else 0 for s in out_state])
             if invert:
@@ -111,7 +113,7 @@ class SamplingResult(dict):
                 distribution.
 
         """
-        mapped_result: dict[State, float] = {}
+        mapped_result: dict[State, int] = {}
         for out_state, val in self.items():
             if invert:
                 new_s = State([1 - (s % 2) for s in out_state])
@@ -123,12 +125,16 @@ class SamplingResult(dict):
                 mapped_result[new_s] = val
         return self._recombine_mapped_result(mapped_result)
 
-    def _recombine_mapped_result(self, mapped_result: dict) -> "SamplingResult":
+    def _recombine_mapped_result(
+        self, mapped_result: dict[State, int]
+    ) -> "SamplingResult":
         """Creates a new Result object from mapped data."""
         return SamplingResult(mapped_result, self.input)
 
     def plot(
-        self, show: bool = True, state_labels: dict | None = None
+        self,
+        show: bool = True,
+        state_labels: dict[State, str | State] | None = None,
     ) -> tuple[matplotlib.figure.Figure, plt.Axes] | None:
         """
         Create a plot of the data contained in the result. This will either
@@ -163,7 +169,7 @@ class SamplingResult(dict):
         labels = [
             state_labels[s] if s in state_labels else str(s) for s in self
         ]
-        ax.set_xticklabels(labels, rotation=90)
+        ax.set_xticklabels(labels, rotation=90)  # type: ignore[arg-type]
         ax.set_xlabel("State")
         ax.set_ylabel("Counts")
 

--- a/lightworks/sdk/tasks/analyzer.py
+++ b/lightworks/sdk/tasks/analyzer.py
@@ -57,7 +57,9 @@ class Analyzer(Task):
         circuit: PhotonicCircuit,
         inputs: State | list[State],
         expected: dict[State, State | list[State]] | None = None,
-        post_selection: PostSelectionType | Callable | None = None,
+        post_selection: PostSelectionType
+        | Callable[[State], bool]
+        | None = None,
     ) -> None:
         # Assign key parameters to attributes
         self.circuit = circuit
@@ -93,7 +95,7 @@ class Analyzer(Task):
 
     @post_selection.setter
     def post_selection(
-        self, value: PostSelectionType | Callable | None
+        self, value: PostSelectionType | Callable[[State], bool] | None
     ) -> None:
         value = process_post_selection(value)
         self.__post_selection = value

--- a/lightworks/sdk/tasks/sampler.py
+++ b/lightworks/sdk/tasks/sampler.py
@@ -81,7 +81,9 @@ class Sampler(Task):
         circuit: PhotonicCircuit,
         input_state: State,
         n_samples: int,
-        post_selection: PostSelectionType | Callable | None = None,
+        post_selection: PostSelectionType
+        | Callable[[State], bool]
+        | None = None,
         min_detection: int = 0,
         source: Source | None = None,
         detector: Detector | None = None,
@@ -179,7 +181,7 @@ class Sampler(Task):
 
     @post_selection.setter
     def post_selection(
-        self, value: PostSelectionType | Callable | None
+        self, value: PostSelectionType | Callable[[State], bool] | None
     ) -> None:
         self.__post_selection = process_post_selection(value)
 

--- a/lightworks/sdk/utils/heralding_utils.py
+++ b/lightworks/sdk/utils/heralding_utils.py
@@ -17,7 +17,9 @@ from copy import copy
 from ..state import State
 
 
-def add_heralds_to_state(state: State | list, heralds: dict) -> list:
+def add_heralds_to_state(
+    state: State | list[int], heralds: dict[int, int]
+) -> list[int]:
     """
     Takes a provided input state and includes any heralding photons/modes.
 
@@ -49,7 +51,9 @@ def add_heralds_to_state(state: State | list, heralds: dict) -> list:
     return new_state
 
 
-def remove_heralds_from_state(state: State | list, herald_modes: list) -> list:
+def remove_heralds_from_state(
+    state: State | list[int], herald_modes: list[int]
+) -> list[int]:
     """
     Removes all heralded modes from a provided state.
 

--- a/lightworks/sdk/utils/matrix_utils.py
+++ b/lightworks/sdk/utils/matrix_utils.py
@@ -17,12 +17,13 @@ Contains a collection of different useful functions for operations on matrices.
 """
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ...__settings import settings
 
 
 def check_unitary(
-    U: np.ndarray,  # noqa: N803
+    U: NDArray[np.complex128],  # noqa: N803
     precision: float | None = None,
 ) -> bool:
     """
@@ -60,7 +61,9 @@ def check_unitary(
     )
 
 
-def add_mode_to_unitary(unitary: np.ndarray, add_mode: int) -> np.ndarray:
+def add_mode_to_unitary(
+    unitary: NDArray[np.complex128], add_mode: int
+) -> NDArray[np.complex128]:
     """
     Adds a new mode (through inclusion of an extra row/column) to the provided
     unitary at the selected location.

--- a/lightworks/sdk/utils/permutation_conversion.py
+++ b/lightworks/sdk/utils/permutation_conversion.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import numpy as np
+from numpy.typing import NDArray
 
 
-def permutation_mat_from_swaps_dict(swaps: dict, n_modes: int) -> np.ndarray:
+def permutation_mat_from_swaps_dict(
+    swaps: dict[int, int], n_modes: int
+) -> NDArray[np.complex128]:
     """
     Calculates the permutation unitary for a given dictionary of swaps across
     the n_modes of a circuit.

--- a/lightworks/sdk/utils/post_selection.py
+++ b/lightworks/sdk/utils/post_selection.py
@@ -141,7 +141,7 @@ class PostSelectionFunction(PostSelectionType):
     Allows for post-selection to be implemented with a provided function.
     """
 
-    def __init__(self, function: Callable) -> None:
+    def __init__(self, function: Callable[[State], bool]) -> None:
         if not isinstance(function, FunctionType):
             raise TypeError("Post-selection not a function.")
         self.__function = function

--- a/lightworks/sdk/utils/post_selection.py
+++ b/lightworks/sdk/utils/post_selection.py
@@ -27,7 +27,7 @@ class PostSelectionType(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def validate(self, state: State) -> bool:
+    def validate(self, state: State | list[int]) -> bool:
         """Enforces all post-selection classes have the validate method."""
 
 
@@ -48,20 +48,22 @@ class PostSelection(PostSelectionType):
         self.__modes_with_rules: set[int] = set()
 
     @property
-    def rules(self) -> list:
+    def rules(self) -> list["Rule"]:
         """
         Returns currently applied post-selection rules.
         """
         return self.__rules
 
     @property
-    def modes(self) -> list:
+    def modes(self) -> list[int]:
         """
         Returns modes on which rules are currently applied.
         """
         return sorted(self.__modes_with_rules)
 
-    def add(self, modes: int | tuple, n_photons: int | tuple) -> None:
+    def add(
+        self, modes: int | tuple[int, ...], n_photons: int | tuple[int, ...]
+    ) -> None:
         """
         Adds a post-selection rule across the provided modes, conditioning that
         the total number of photons across the modes is equal to any of the
@@ -100,7 +102,7 @@ class PostSelection(PostSelectionType):
         for m in modes:
             self.__modes_with_rules.add(m)
 
-    def validate(self, state: State) -> bool:
+    def validate(self, state: State | list[int]) -> bool:
         """
         Validates whether a provided State meets the set post-selection
         criteria.
@@ -124,14 +126,14 @@ class Rule:
     Stores a post-selection rule for a number of modes and n_photons.
     """
 
-    modes: tuple[int]
-    n_photons: tuple[int]
+    modes: tuple[int, ...]
+    n_photons: tuple[int, ...]
 
-    def as_tuple(self) -> tuple:
+    def as_tuple(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
         """Returns a tuple representation of the post-selection rule."""
         return (self.modes, self.n_photons)
 
-    def validate(self, state: State) -> bool:
+    def validate(self, state: State | list[int]) -> bool:
         """Validates a provided state meets the post-selection rule."""
         return sum(state[m] for m in self.modes) in self.n_photons
 
@@ -146,7 +148,7 @@ class PostSelectionFunction(PostSelectionType):
             raise TypeError("Post-selection not a function.")
         self.__function = function
 
-    def validate(self, state: State) -> bool:
+    def validate(self, state: State | list[int]) -> bool:
         """
         Validates whether a provided State meets the set post-selection
         criteria.
@@ -169,14 +171,14 @@ class DefaultPostSelection(PostSelectionType):
     Provides a default post-selection function which always returns True.
     """
 
-    def validate(self, state: State) -> bool:  # noqa: ARG002
+    def validate(self, state: State | list[int]) -> bool:  # noqa: ARG002
         """
         Will return True regardless of provided state.
         """
         return True
 
 
-def check_int_or_tuple(value: int | Sequence) -> tuple:
+def check_int_or_tuple(value: int | Sequence[int]) -> tuple[int, ...]:
     """
     Process a provided value, if it is a sequence then it will check all values
     are integers, otherwise it will validate the value and convert to a tuple.

--- a/lightworks/sdk/utils/post_selection_processing.py
+++ b/lightworks/sdk/utils/post_selection_processing.py
@@ -15,12 +15,13 @@
 from collections.abc import Callable
 from types import FunctionType, NoneType
 
+from ..state import State
 from . import PostSelectionFunction
 from .post_selection import PostSelectionType
 
 
 def process_post_selection(
-    post_selection: PostSelectionType | Callable | None,
+    post_selection: PostSelectionType | Callable[[State], bool] | None,
 ) -> PostSelectionType | None:
     """
     Takes a provided post-selection value and converts this into one of the

--- a/lightworks/sdk/utils/random_utils.py
+++ b/lightworks/sdk/utils/random_utils.py
@@ -16,6 +16,7 @@ from types import NoneType
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy.stats import unitary_group
 
 
@@ -41,7 +42,10 @@ def process_random_seed(seed: Any) -> int | None:
     return seed
 
 
-def random_unitary(N: int, seed: int | None = None) -> np.ndarray:  # noqa: N803
+def random_unitary(
+    N: int,  # noqa: N803
+    seed: int | None = None,
+) -> NDArray[np.complex128]:
     """
     Generate a random NxN unitary matrix. Seed can be used to produce the same
     unitary each time the function is called.
@@ -71,7 +75,7 @@ def random_unitary(N: int, seed: int | None = None) -> np.ndarray:  # noqa: N803
 def random_permutation(
     N: int,  # noqa: N803
     seed: int | None = None,
-) -> np.ndarray:
+) -> NDArray[np.complex128]:
     """
     Generate a random NxN permutation. Seed can be used to produce the same
     unitary each time the function is called.

--- a/lightworks/sdk/utils/state_utils.py
+++ b/lightworks/sdk/utils/state_utils.py
@@ -17,7 +17,7 @@ Script to store various useful functions for the simulation aspect of the code.
 """
 
 
-def state_to_string(state: list) -> str:
+def state_to_string(state: list[int]) -> str:
     """Converts the provided state to a string with ket notation."""
     string = "|"
     for s in state:

--- a/lightworks/sdk/visualisation/display_components_svg.py
+++ b/lightworks/sdk/visualisation/display_components_svg.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 import drawsvg as draw
 import numpy as np
 
@@ -29,7 +31,7 @@ class DrawSVGComponents:
 
         return
 
-    def add(self, draw_spec: list[tuple]) -> None:
+    def add(self, draw_spec: list[tuple[str, tuple[Any, ...]]]) -> None:
         """
         Adds components to the provided drawing using the draw spec.
         """
@@ -150,7 +152,9 @@ class DrawSVGComponents:
         self.d.append(t)
         return
 
-    def _draw_mode_swaps(self, x: float, ys: list, size_x: float) -> None:
+    def _draw_mode_swaps(
+        self, x: float, ys: list[tuple[float, float]], size_x: float
+    ) -> None:
         for y0, y1 in ys:
             w = self.wg_width / 2
             m = np.arctan(abs(y1 - y0) / size_x)

--- a/lightworks/sdk/visualisation/draw_circuit_mpl.py
+++ b/lightworks/sdk/visualisation/draw_circuit_mpl.py
@@ -604,7 +604,10 @@ class DrawCircuitMPL:
         return
 
     def _add_heralds(
-        self, heralds: dict, start_loc: float, end_loc: float
+        self,
+        heralds: dict[str, dict[int, int]],
+        start_loc: float,
+        end_loc: float,
     ) -> None:
         """
         Adds display of all heralds to circuit.

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -72,7 +72,7 @@ class DrawCircuitSVG:
         # Set a waveguide width and get mode number
         self.wg_width = 8
         self.n_modes = self.circuit.n_modes
-        self.draw_spec: list[tuple] = []
+        self.draw_spec: list[tuple[str, tuple[Any, ...]]] = []
         self.dy = 125
         self.dy_smaller = 75
         self.y_locations = []
@@ -624,7 +624,10 @@ class DrawCircuitSVG:
         return
 
     def _add_heralds(
-        self, heralds: dict, start_loc: float, end_loc: float
+        self,
+        heralds: dict[str, dict[int, int]],
+        start_loc: float,
+        end_loc: float,
     ) -> None:
         """
         Adds display of all heralds to circuit.

--- a/lightworks/tomography/gate_fidelity.py
+++ b/lightworks/tomography/gate_fidelity.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import numpy as np
+from numpy.typing import NDArray
 
+from ..sdk.state import State
 from .mappings import PAULI_MAPPING, RHO_MAPPING
 from .process_tomography import ProcessTomography
 from .utils import _calculate_density_matrix, _combine_all, _vec
@@ -56,7 +58,7 @@ class GateFidelity(ProcessTomography):
             )
         return self._fidelity
 
-    def process(self, target_process: np.ndarray) -> float:
+    def process(self, target_process: NDArray[np.complex128]) -> float:
         """
         Calculates gate fidelity for an expected target process
 
@@ -75,7 +77,7 @@ class GateFidelity(ProcessTomography):
         all_inputs = _combine_all(TOMO_INPUTS, self.n_qubits)
         results = self._run_required_experiments(all_inputs)
         # Sorted results per input
-        remapped_results: dict[str, dict[str, dict]] = {
+        remapped_results: dict[str, dict[str, dict[State, int]]] = {
             k[0]: {} for k in results
         }
         for (k1, k2), r in results.items():
@@ -104,7 +106,7 @@ class GateFidelity(ProcessTomography):
 
     def _calculate_alpha_and_u_basis(
         self,
-    ) -> tuple[np.ndarray, list[np.ndarray]]:
+    ) -> tuple[NDArray[np.complex128], list[NDArray[np.complex128]]]:
         """
         Calculates the pauli matrix basis to use for the calculation and finds
         the coefficients of the alpha matrix used which can be used to the

--- a/lightworks/tomography/mappings.py
+++ b/lightworks/tomography/mappings.py
@@ -13,26 +13,27 @@
 # limitations under the License.
 
 import numpy as np
+from numpy.typing import NDArray
 
 from .. import qubit
 from ..sdk.circuit import PhotonicCircuit
 from ..sdk.state import State
 
-PAULI_MAPPING: dict[str, np.ndarray] = {
-    "I": np.array([[1, 0], [0, 1]]),
-    "X": np.array([[0, 1], [1, 0]]),
-    "Y": np.array([[0, -1j], [1j, 0]]),
-    "Z": np.array([[1, 0], [0, -1]]),
+PAULI_MAPPING: dict[str, NDArray[np.complex128]] = {
+    "I": np.array([[1, 0], [0, 1]], dtype=np.complex128),
+    "X": np.array([[0, 1], [1, 0]], dtype=np.complex128),
+    "Y": np.array([[0, -1j], [1j, 0]], dtype=np.complex128),
+    "Z": np.array([[1, 0], [0, -1]], dtype=np.complex128),
 }
 
 # Pre-calculated density matrices for different quantum states
-RHO_MAPPING: dict[str, np.ndarray] = {
-    "X+": np.array([[1, 1], [1, 1]]) / 2,
-    "X-": np.array([[1, -1], [-1, 1]]) / 2,
-    "Y+": np.array([[1, -1j], [1j, 1]]) / 2,
-    "Y-": np.array([[1, 1j], [-1j, 1]]) / 2,
-    "Z+": np.array([[1, 0], [0, 0]]),
-    "Z-": np.array([[0, 0], [0, 1]]),
+RHO_MAPPING: dict[str, NDArray[np.complex128]] = {
+    "X+": np.array([[1, 1], [1, 1]], dtype=np.complex128) / 2,
+    "X-": np.array([[1, -1], [-1, 1]], dtype=np.complex128) / 2,
+    "Y+": np.array([[1, -1j], [1j, 1]], dtype=np.complex128) / 2,
+    "Y-": np.array([[1, 1j], [-1j, 1]], dtype=np.complex128) / 2,
+    "Z+": np.array([[1, 0], [0, 0]], dtype=np.complex128),
+    "Z-": np.array([[0, 0], [0, 1]], dtype=np.complex128),
 }
 
 # Details the actual input state and transformation required to achieve a target

--- a/lightworks/tomography/process_tomography.py
+++ b/lightworks/tomography/process_tomography.py
@@ -14,6 +14,7 @@
 
 from collections.abc import Callable
 from types import FunctionType, MethodType
+from typing import Any
 
 from ..sdk.circuit import PhotonicCircuit
 from ..sdk.state import State
@@ -54,8 +55,10 @@ class ProcessTomography:
         self,
         n_qubits: int,
         base_circuit: PhotonicCircuit,
-        experiment: Callable,
-        experiment_args: list | None = None,
+        experiment: Callable[
+            [list[PhotonicCircuit], list[State]], list[dict[State, int]]
+        ],
+        experiment_args: list[Any] | None = None,
     ) -> None:
         # Type check inputs
         if not isinstance(n_qubits, int) or isinstance(n_qubits, bool):
@@ -92,7 +95,9 @@ class ProcessTomography:
         return self._n_qubits
 
     @property
-    def experiment(self) -> Callable:
+    def experiment(
+        self,
+    ) -> Callable[[list[PhotonicCircuit], list[State]], list[dict[State, int]]]:
         """
         A function to call which runs the required experiments. This should
         accept a list of circuits as a single argument and then return a list
@@ -102,7 +107,12 @@ class ProcessTomography:
         return self._experiment
 
     @experiment.setter
-    def experiment(self, value: Callable) -> None:
+    def experiment(
+        self,
+        value: Callable[
+            [list[PhotonicCircuit], list[State]], list[dict[State, int]]
+        ],
+    ) -> None:
         if not isinstance(value, FunctionType | MethodType):
             raise TypeError(
                 "Provided experiment should be a function which accepts a list "

--- a/lightworks/tomography/process_tomography_li.py
+++ b/lightworks/tomography/process_tomography_li.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import numpy as np
+from numpy.typing import NDArray
 
+from ..sdk.state import State
 from .mappings import PAULI_MAPPING, RHO_MAPPING
 from .process_tomography import ProcessTomography
 from .utils import (
@@ -52,7 +54,7 @@ class LIProcessTomography(ProcessTomography):
     """
 
     @property
-    def choi(self) -> np.ndarray:
+    def choi(self) -> NDArray[np.complex128]:
         """Returns the calculate choi matrix for a circuit."""
         if not hasattr(self, "_choi"):
             raise AttributeError(
@@ -61,7 +63,7 @@ class LIProcessTomography(ProcessTomography):
             )
         return self._choi
 
-    def process(self) -> np.ndarray:
+    def process(self) -> NDArray[np.complex128]:
         """
         Performs process tomography with the configured elements and calculates
         the choi matrix using linear inversion.
@@ -92,7 +94,7 @@ class LIProcessTomography(ProcessTomography):
         self._choi = _unvec(choi)
         return self.choi
 
-    def fidelity(self, choi_exp: np.ndarray) -> float:
+    def fidelity(self, choi_exp: NDArray[np.complex128]) -> float:
         """
         Calculates fidelity of the calculated choi matrix compared to the
         expected one.
@@ -100,7 +102,7 @@ class LIProcessTomography(ProcessTomography):
         return process_fidelity(self.choi, choi_exp)
 
     def _calculate_expectation_values(
-        self, results: dict[tuple[str, str], dict]
+        self, results: dict[tuple[str, str], dict[State, int]]
     ) -> dict[tuple[str, str], float]:
         """
         Calculates the expectation values from a set of results containing,

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import numpy as np
 from multimethod import multimethod
+from numpy.typing import NDArray
 from scipy.linalg import sqrtm
 
 from lightworks.sdk.state import State
@@ -26,7 +27,9 @@ from .mappings import MEASUREMENT_MAPPING, PAULI_MAPPING
 # should begin with _
 
 
-def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
+def state_fidelity(
+    rho: NDArray[np.complex128], rho_exp: NDArray[np.complex128]
+) -> float:
     """
     Calculates the fidelity of the density matrix for a quantum state against
     the expected density matrix.
@@ -54,7 +57,9 @@ def state_fidelity(rho: np.ndarray, rho_exp: np.ndarray) -> float:
     return abs(np.trace(sqrtm(inner)))
 
 
-def process_fidelity(choi: np.ndarray, choi_exp: np.ndarray) -> float:
+def process_fidelity(
+    choi: NDArray[np.complex128], choi_exp: NDArray[np.complex128]
+) -> float:
     """
     Calculates the fidelity of a process compared to an expected choi matrix.
 
@@ -79,7 +84,9 @@ def process_fidelity(choi: np.ndarray, choi_exp: np.ndarray) -> float:
     return state_fidelity(choi / 2**n_qubits, choi_exp / 2**n_qubits)
 
 
-def density_from_state(state: list | np.ndarray) -> np.ndarray:
+def density_from_state(
+    state: list[complex] | NDArray[np.complex128],
+) -> NDArray[np.complex128]:
     """
     Calculates the expected density matrix from a given state.
 
@@ -97,7 +104,9 @@ def density_from_state(state: list | np.ndarray) -> np.ndarray:
     return np.outer(state, np.conj(state.T))
 
 
-def choi_from_unitary(unitary: np.ndarray) -> np.ndarray:
+def choi_from_unitary(
+    unitary: NDArray[np.complex128],
+) -> NDArray[np.complex128]:
     """
     Calculates the expected choi matrix from a given unitary representation of a
     process.
@@ -115,14 +124,14 @@ def choi_from_unitary(unitary: np.ndarray) -> np.ndarray:
     return np.outer(unitary.flatten(), np.conj(unitary.flatten()))
 
 
-def _vec(mat: np.ndarray) -> np.ndarray:
+def _vec(mat: NDArray[Any]) -> NDArray[Any]:
     """
     Applies flatten operation to a provided matrix to convert it into a vector.
     """
     return mat.flatten()
 
 
-def _unvec(mat: np.ndarray) -> np.ndarray:
+def _unvec(mat: NDArray[Any]) -> NDArray[Any]:
     """
     Takes a provided vector and converts it into a square matrix.
     """
@@ -139,7 +148,7 @@ def _combine_all(value: Any, n: int) -> None:  # noqa: ARG001
 
 
 @_combine_all.register
-def _combine_all_list(value: list[str], n: int) -> list:
+def _combine_all_list(value: list[str], n: int) -> list[str]:
     """
     Sums string values within list.
     """
@@ -150,7 +159,9 @@ def _combine_all_list(value: list[str], n: int) -> list:
 
 
 @_combine_all.register
-def _combine_all_list_array(value: list[np.ndarray], n: int) -> list:
+def _combine_all_list_array(
+    value: list[NDArray[Any]], n: int
+) -> list[NDArray[Any]]:
     """
     Performs tensor product of all combinations of arrays within list.
     """
@@ -161,7 +172,9 @@ def _combine_all_list_array(value: list[np.ndarray], n: int) -> list:
 
 
 @_combine_all.register
-def _combine_all_dict_mat(value: dict[str, np.ndarray], n: int) -> dict:
+def _combine_all_dict_mat(
+    value: dict[str, NDArray[Any]], n: int
+) -> dict[str, NDArray[Any]]:
     """
     Sums keys of dictionary and performs tensor products of the dictionary
     values.
@@ -202,7 +215,7 @@ def _get_tomo_measurements(
 
 def _get_required_tomo_measurements(
     n_qubits: int, remove_trivial: bool = False
-) -> tuple[list, dict]:
+) -> tuple[list[str], dict[str, str]]:
     """
     Calculates reduced list of required measurements assuming that any
     measurements in the I basis can be replaced with a Z measurement.
@@ -275,8 +288,8 @@ def _calculate_expectation_value(
 
 
 def _calculate_density_matrix(
-    results: dict[str, dict], n_qubits: int
-) -> np.ndarray:
+    results: dict[str, dict[State, int]], n_qubits: int
+) -> NDArray[np.complex128]:
     """
     Calculates the density matrix using a provided dictionary of results
     data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,10 @@ strict_equality = true
 extra_checks = true
 check_untyped_defs = true
 
+disallow_any_generics = true
+disallow_incomplete_defs = true
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
-disallow_incomplete_defs = true
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
# Summary

Adds the mypy disallow_any_generics option, enforcing more complete type hint across Lightworks. Hints have been added in all relevant places, and a few small issues corrected.
