### PR TITLE
Removed maximum python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [lightworks]
-requires-python = ">=3.10,<=3.13"
+requires-python = ">=3.10"
 
 ## pytest config
 [tool.pytest.ini_options]


### PR DESCRIPTION
# Summary

Removed the maximum python version in pyproject.toml due to issues this could cause with future releases.
