### PR TITLE
Result base class

### DIFF
--- a/lightworks/emulator/backends/backend.py
+++ b/lightworks/emulator/backends/backend.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 
-from typing import Any
+from typing import Any, overload
 
 from multimethod import multimethod
 
 from lightworks.emulator.utils.exceptions import BackendError
+from lightworks.sdk.results import Result
 from lightworks.sdk.tasks import Batch, Task
 
 from .permanent import PermanentBackend
@@ -38,7 +39,15 @@ class Backend:
     def __init__(self, backend: str) -> None:
         self.backend = backend
 
-    def run(self, task: Task | Batch) -> dict[Any, Any] | list[dict[Any, Any]]:
+    @overload
+    def run(self, task: Task) -> Result[Any, Any]: ...
+
+    @overload
+    def run(self, task: Batch) -> list[Result[Any, Any]]: ...
+
+    def run(
+        self, task: Task | Batch
+    ) -> Result[Any, Any] | list[Result[Any, Any]]:
         """
         Runs the provided task on the current backend.
 
@@ -48,10 +57,10 @@ class Backend:
 
         Returns:
 
-            dict: A dictionary like results object containing details of the
-                calculated values from a task. If a batch is run then this will
-                be a list of results in the same order the task were added to
-                the batch.
+            Result|list[Result]: A dictionary like results object containing
+                details of the calculated values from a task. If a batch is run
+                then this will be a list of results in the same order the task
+                were added to the batch.
 
         """
         if not isinstance(task, Task | Batch):

--- a/lightworks/sdk/results/result.py
+++ b/lightworks/sdk/results/result.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .probability_distribution import ProbabilityDistribution
-from .result import Result
-from .sampling_result import SamplingResult
-from .simulation_result import SimulationResult
+from typing import TypeVar
+
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
+
+
+class Result(dict[_KT, _VT]):
+    """
+    Base class for all Lightworks result objects.
+    """

--- a/lightworks/sdk/results/result.py
+++ b/lightworks/sdk/results/result.py
@@ -12,13 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TypeVar
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from lightworks.sdk.state import State
 
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
 
+RT = TypeVar("RT")
 
-class Result(dict[_KT, _VT]):
+
+class Result(dict[_KT, _VT], ABC):
     """
     Base class for all Lightworks result objects.
     """
+
+    @abstractmethod
+    def map(
+        self: RT,
+        mapping: Callable[[State, Any], State],
+        *args: Any,
+        **kwargs: Any,
+    ) -> RT:
+        """
+        Requires ability to apply a state mapping on a particular result.
+        """

--- a/lightworks/sdk/results/sampling_result.py
+++ b/lightworks/sdk/results/sampling_result.py
@@ -24,8 +24,10 @@ import pandas as pd
 from lightworks.sdk.state import State
 from lightworks.sdk.utils.exceptions import ResultCreationError
 
+from .result import Result
 
-class SamplingResult(dict[State, int]):
+
+class SamplingResult(Result[State, int]):
     """
     Stores results data from a sampling experiment in the emulator. There is
     then a range of options for displaying the data, or alternatively the data

--- a/lightworks/sdk/results/simulation_result.py
+++ b/lightworks/sdk/results/simulation_result.py
@@ -25,8 +25,10 @@ from numpy.typing import NDArray
 from lightworks.sdk.state import State
 from lightworks.sdk.utils.exceptions import ResultCreationError
 
+from .result import Result
 
-class SimulationResult(dict[State, dict[State, float | complex]]):
+
+class SimulationResult(Result[State, dict[State, float | complex]]):
     """
     Stores results data from a given simulation in the emulator. There is then
     a range of options for displaying the data, or alternatively the data can


### PR DESCRIPTION
# Summary

Add a base `Result` class for `SamplingResult` & `SimulationResult` with an abstract method which enforces the inclusion of the map method. This is intended to simplify typing across Lightworks + extensions.
