### PR TITLE
Package type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     },
     license="Apache 2.0",
     packages=find_packages(where=".", exclude=["tests"]),
+    package_data={"lightworks": ["py.typed"]},
     python_requires=">=3.10",
     install_requires=[
         "thewalrus==0.20.0",


### PR DESCRIPTION
# Summary

Adds the required py.typed file and setup.py configuration for package type hints to be read by tools such as mypy.
