### PR TITLE
Analyzer herald bug

### DIFF
--- a/lightworks/emulator/simulation/analyzer.py
+++ b/lightworks/emulator/simulation/analyzer.py
@@ -82,7 +82,7 @@ class AnalyzerRunner(RunnerABC):
             + [0] * self.data.circuit.loss_modes
             for i in inputs
         ]
-        n_photons = sum(full_inputs[0])
+        n_photons = sum(inputs[0])
         # Generate lists of possible outputs with and without heralded modes
         full_outputs, filtered_outputs = self._generate_outputs(
             n_modes, n_photons


### PR DESCRIPTION
# Summary

Fixes a bug in which heralded photons were being counted twice in the simulation runner for `Analyzer` tasks, causing incorrect output states to be generated and therefore an exception to be raised. A test has also been added to validate this issue in the future.