### PR TITLE
Restrict result edit and ruff fix

### DIFF
--- a/lightworks/sdk/circuit/parameters.py
+++ b/lightworks/sdk/circuit/parameters.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import UserDict
 from math import inf
 from numbers import Number
 from types import NoneType
@@ -162,7 +163,7 @@ def is_numeric(value: Any) -> bool:
     return isinstance(value, Number) and not isinstance(value, bool)
 
 
-class ParameterDict(dict[str, Parameter[Any]]):
+class ParameterDict(UserDict[str, Parameter[Any]]):
     """
     Stores a number of Parameters, using assigned keys to reference each
     Parameter object. This has custom get and set item which allows for the

--- a/lightworks/sdk/results/probability_distribution.py
+++ b/lightworks/sdk/results/probability_distribution.py
@@ -16,7 +16,7 @@ from lightworks.sdk.state import State
 from lightworks.sdk.utils.exceptions import ProbabilityDistributionError
 
 
-class ProbabilityDistribution(dict[State, float]):
+class ProbabilityDistribution(dict[State, float]):  # noqa: FURB189
     """
     Stores a created ProbabilityDistribution and prevents modification to
     values.

--- a/lightworks/sdk/results/result.py
+++ b/lightworks/sdk/results/result.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from lightworks.sdk.state import State
+from lightworks.sdk.utils.exceptions import ResultError
 
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
@@ -39,3 +40,9 @@ class Result(dict[_KT, _VT], ABC):
         """
         Requires ability to apply a state mapping on a particular result.
         """
+
+    def __setitem__(self, key: _KT, value: _VT) -> None:
+        raise ResultError(
+            "Result objects should not be modified directly. To get a copy of "
+            "the data which can be modified use dict(Result)."
+        )

--- a/lightworks/sdk/utils/exceptions.py
+++ b/lightworks/sdk/utils/exceptions.py
@@ -75,9 +75,15 @@ class DecompositionUnsuccessful(LightworksError):  # noqa: N818
     """
 
 
-class ResultCreationError(LightworksError):
+class ResultError(LightworksError):
     """
-    For specific errors which occur when using creating a Result object.
+    For specific errors which occur when using a Result object.
+    """
+
+
+class ResultCreationError(ResultError):
+    """
+    For specific errors which occur when creating a Result object.
     """
 
 


### PR DESCRIPTION
# Summary

Adds custom __setitem__ method of `Result` to prevent accidental modification of Results. Instead, a copy should first be made using dict(Result).

Also fixes a new issue raised by ruff, for some instances where dict is inherited by a class. For the ParameterDict this was solved by inheriting from UserDict instead.  