### PR TITLE
Doi link

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,9 +16,7 @@ authors:
     post-code: S1 2NS
     country: GB
     website: 'https://aegiq.com'
-identifiers:
-  - type: doi
-    value: 10.5281/zenodo.14925692
+doi: 10.5281/zenodo.14925692
 repository-code: 'https://github.com/Aegiq/lightworks'
 url: 'https://aegiq.github.io/lightworks/'
 repository-artifact: 'https://pypi.org/project/lightworks/'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Tests](https://github.com/Aegiq/lightworks/actions/workflows/tests.yml/badge.svg?event=push)](https://github.com/Aegiq/lightworks/actions/workflows/tests.yml)
 [![Docs](https://github.com/Aegiq/lightworks/actions/workflows/sphinx_deploy.yml/badge.svg?event=push)](https://github.com/Aegiq/lightworks/actions/workflows/sphinx_deploy.yml)
 [![Pyversions](https://img.shields.io/pypi/pyversions/lightworks.svg?style=plastic)](https://pypi.org/project/lightworks/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14925692.svg)](https://doi.org/10.5281/zenodo.14925692)
 
 
 # Lightworks


### PR DESCRIPTION
# Summary

Adds a Lightworks doi link (from zenodo) to the citation file and the readme.
