### PR TITLE
Fix tomography experiment order

### DIFF
--- a/lightworks/emulator/__init__.py
+++ b/lightworks/emulator/__init__.py
@@ -32,9 +32,6 @@ Simulators:
         circuit, and enables sampling from it. Imperfect sources and detectors
         can also be utilised here.
 
-    QuickSampler : A faster sampler, which can be used in cases where photon
-        number should be preserved and source is perfect.
-
     Analyzer : Finds all possible outputs of a circuit with a given set of
         inputs, conditional on them meeting a set of post-selection and
         heralding criteria. This means it can be used to analyze how well a

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -247,6 +247,7 @@ def _get_required_tomo_measurements(
         for c in _get_tomo_measurements(n_qubits, remove_trivial=remove_trivial)
     }
     req_measurements = list(set(mapping.values()))
+    req_measurements.sort()
     return req_measurements, mapping
 
 

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -165,3 +165,12 @@ class TestUtils:
         3^n_qubits.
         """
         assert len(_get_required_tomo_measurements(n_qubits)[0]) == 3**n_qubits
+
+    @pytest.mark.parametrize("n_qubits", [1, 3])
+    def test_required_measurements_order(self, n_qubits):
+        """
+        Checks that the required measurements function always returns a sorted
+        list for consistency between runs.
+        """
+        req_meas = _get_required_tomo_measurements(n_qubits)[0]
+        assert req_meas == sorted(req_meas)


### PR DESCRIPTION
# Summary

This PR fixes an issue which caused the order of the required experiment when running tomography algorithms to be random between different calls. This could cause issues when trying to save and recover data at a later date while expecting the ordering to remain consistent.

It also makes a minor tweak to the description of the init file in the emulator, removing some old information.
