### PR TITLE
Validate number of output heralds against input

### DIFF
--- a/lightworks/sdk/tasks/analyzer.py
+++ b/lightworks/sdk/tasks/analyzer.py
@@ -20,7 +20,7 @@ from lightworks.sdk.utils.post_selection import (
     PostSelectionType,
     process_post_selection,
 )
-from lightworks.sdk.utils.state import validate_states
+from lightworks.sdk.utils.state import check_herald_difference, validate_states
 
 from .data import AnalyzerTask
 from .task import Task
@@ -123,6 +123,7 @@ class Analyzer(Task):
         self.__expected = value
 
     def _generate_task(self) -> AnalyzerTask:
+        check_herald_difference(self.circuit, self.inputs[0].n_photons)
         return AnalyzerTask(
             circuit=self.circuit._build(),
             inputs=self.inputs,

--- a/lightworks/sdk/tasks/sampler.py
+++ b/lightworks/sdk/tasks/sampler.py
@@ -25,6 +25,7 @@ from lightworks.sdk.utils.post_selection import (
     process_post_selection,
 )
 from lightworks.sdk.utils.random import process_random_seed
+from lightworks.sdk.utils.state import check_herald_difference
 
 from .data import SamplerTask
 from .task import Task
@@ -244,6 +245,7 @@ class Sampler(Task):
         return self._probability_distribution
 
     def _generate_task(self) -> SamplerTask:
+        check_herald_difference(self.circuit, self.input_state.n_photons)
         return SamplerTask(
             circuit=self.circuit._build(),
             input_state=self.input_state,

--- a/lightworks/sdk/tasks/simulator.py
+++ b/lightworks/sdk/tasks/simulator.py
@@ -15,7 +15,7 @@
 
 from lightworks.sdk.circuit import PhotonicCircuit
 from lightworks.sdk.state import State
-from lightworks.sdk.utils.state import validate_states
+from lightworks.sdk.utils.state import check_herald_difference, validate_states
 
 from .data import SimulatorTask
 from .task import Task
@@ -92,6 +92,7 @@ class Simulator(Task):
         self.__outputs = value
 
     def _generate_task(self) -> SimulatorTask:
+        check_herald_difference(self.circuit, self.inputs[0].n_photons)
         return SimulatorTask(
             circuit=self.circuit._build(),
             inputs=self.inputs,

--- a/lightworks/sdk/utils/state.py
+++ b/lightworks/sdk/utils/state.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from lightworks.sdk.circuit import PhotonicCircuit
 from lightworks.sdk.state import State
 
-from .exceptions import ModeMismatchError
+from .exceptions import ModeMismatchError, PhotonNumberError
 
 
 def validate_states(states: State | list[State], n_modes: int) -> list[State]:
@@ -41,3 +42,22 @@ def validate_states(states: State | list[State], n_modes: int) -> list[State]:
         # Also validate state values
         s._validate()
     return states
+
+
+def check_herald_difference(
+    circuit: PhotonicCircuit, input_photons: int
+) -> None:
+    """
+    Validates that the number of output heralds is not too large based on the
+    number of inputs to the circuit.
+    """
+    photon_diff = sum(circuit.heralds.output.values()) - sum(
+        circuit.heralds.input.values()
+    )
+    if photon_diff > input_photons:
+        msg = (
+            "Number of input photons is smaller than that required based "
+            "on the number of heralds at the output. At least "
+            f"{photon_diff} input photons are required."
+        )
+        raise PhotonNumberError(msg)

--- a/tests/emulator/analyzer_test.py
+++ b/tests/emulator/analyzer_test.py
@@ -19,6 +19,7 @@ from lightworks import (
     Analyzer,
     Parameter,
     PhotonicCircuit,
+    PhotonNumberError,
     PostSelection,
     State,
     Unitary,
@@ -323,3 +324,14 @@ class TestAnalyzer:
                 pytest.approx(results_h[State([0, 1, 1, 0]), output])
                 == results[State([0, 1, 0, 1, 1, 0]), full_state]
             )
+
+    def test_output_heralds_too_large(self):
+        """
+        Confirms a PhotonNumberError is raised when the number of output heralds
+        is larger than the number of photons input into the system.
+        """
+        circuit = Unitary(random_unitary(4))
+        circuit.herald(3, (0, 2))
+        sim = Analyzer(circuit, State([1, 0, 0]))
+        with pytest.raises(PhotonNumberError):
+            sim._generate_task()

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -18,6 +18,7 @@ from lightworks import (
     ModeMismatchError,
     Parameter,
     PhotonicCircuit,
+    PhotonNumberError,
     PostSelection,
     Sampler,
     State,
@@ -257,6 +258,17 @@ class TestSamplerGeneral:
         b2 = Backend("slos")
         # Check attribute doesn't exist
         assert not hasattr(b2._Backend__backend, "_cache")
+
+    def test_output_heralds_too_large(self):
+        """
+        Confirms a PhotonNumberError is raised when the number of output heralds
+        is larger than the number of photons input into the system.
+        """
+        circuit = Unitary(random_unitary(4))
+        circuit.herald(3, (0, 2))
+        sampler = Sampler(circuit, State([1, 0, 0]), 1000)
+        with pytest.raises(PhotonNumberError):
+            sampler._generate_task()
 
 
 @pytest.mark.parametrize("backend", [Backend("permanent"), Backend("slos")])

--- a/tests/emulator/simulator_test.py
+++ b/tests/emulator/simulator_test.py
@@ -348,3 +348,14 @@ class TestSimulator:
                 pytest.approx(results_h[State([0, 1, 1, 0]), output])
                 == results[State([0, 1, 0, 1, 1, 0]), full_state]
             )
+
+    def test_output_heralds_too_large(self):
+        """
+        Confirms a PhotonNumberError is raised when the number of output heralds
+        is larger than the number of photons input into the system.
+        """
+        circuit = Unitary(random_unitary(4))
+        circuit.herald(3, (0, 2))
+        sim = Simulator(circuit, State([1, 0, 0]))
+        with pytest.raises(PhotonNumberError):
+            sim._generate_task()


### PR DESCRIPTION
# Summary

Adds a check to confirm the number of input heralds is sufficient for the required heralding number at the output. This previously would fail anyway in most cases, but a more descriptive error message has been added to guide users.
