### PR TITLE
Circuit figure saving & display switch

### DIFF
--- a/docs/source/sdk_reference/display.rst
+++ b/docs/source/sdk_reference/display.rst
@@ -1,5 +1,5 @@
 Display
 =======
 
-.. autoclass:: lightworks.Display
+.. autoclass:: lightworks.display
     :members:

--- a/lightworks/__init__.py
+++ b/lightworks/__init__.py
@@ -62,7 +62,7 @@ from .sdk.utils import (
     random_unitary,
 )
 from .sdk.utils.exceptions import *
-from .sdk.visualisation import Display
+from .sdk.visualisation import display
 
 # If installed then also import the remote module
 with contextlib.suppress(ModuleNotFoundError):
@@ -71,7 +71,6 @@ with contextlib.suppress(ModuleNotFoundError):
 __all__ = [
     "Analyzer",
     "Batch",
-    "Display",
     "Parameter",
     "ParameterDict",
     "PhotonicCircuit",
@@ -82,6 +81,7 @@ __all__ = [
     "State",
     "Unitary",
     "convert",
+    "display",
     "emulator",
     "interferometers",
     "qubit",

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -514,7 +514,7 @@ class PhotonicCircuit:
 
     def save_figure(
         self,
-        path: str,
+        path: str | Path,
         svg: bool = True,
         show_parameter_values: bool = False,
         display_loss: bool = False,
@@ -523,6 +523,28 @@ class PhotonicCircuit:
         """
         Creates a figure of the current circuit and saves this to the provided
         file name.
+
+        Args:
+
+            path (str|Path) : The path to save the figure to. This can be just a
+                filename or can also include a directory which the circuit
+                should be placed within.
+
+            svg (bool, optional) : Controls whether the figure is saved as an
+                svg (True) or png (False). png requires installing the cairosvg
+                module. Defaults to svg.
+
+            show_parameter_values (bool, optional) : Shows the values of
+                parameters instead of the associated labels if specified.
+
+            display_loss (bool, optional) : Choose whether to display loss
+                components in the figure, defaults to False.
+
+            mode_labels (list|None, optional) : Optionally provided a list of
+                mode labels which will be used to name the mode something other
+                than numerical values. Can be set to None to use default
+                values.
+
         """
         figure = display(
             self,
@@ -539,8 +561,8 @@ class PhotonicCircuit:
         else:
             if not CAIROSVG_INSTALLED:
                 raise ModuleNotFoundError(
-                    "cairosvg module is required to save circuit figures as "
-                    "PNGs. The best way to install this dependency is with 'pip"
+                    "cairosvg module is required to save circuit figures as a "
+                    "png. The best way to install this dependency is with 'pip"
                     " install drawsvg[raster]'."
                 )
             figure.set_pixel_scale(5)

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -29,6 +29,7 @@ from numpy.typing import NDArray
 
 from lightworks.sdk.utils.exceptions import (
     CircuitCompilationError,
+    LightworksDependencyError,
     ModeRangeError,
 )
 from lightworks.sdk.utils.param_unitary import ParameterizedUnitary
@@ -559,7 +560,15 @@ class PhotonicCircuit:
             figure.save_svg(p)
         else:
             figure.set_pixel_scale(5)
-            figure.save_png(str(p))
+            try:
+                figure.save_png(str(p))
+            except ImportError as e:
+                raise LightworksDependencyError(
+                    "Unable to save figure as png due to missing dependency."
+                    "Please see original exception for more information or "
+                    "seek support. Alternatively, it will still be possible to "
+                    "save the figure as an svg."
+                ) from e
 
     def get_all_params(self) -> list[Parameter[Any]]:
         """

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -19,7 +19,7 @@ modified after creation.
 
 from collections.abc import Iterable
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -475,7 +475,7 @@ class PhotonicCircuit:
         show_parameter_values: bool = False,
         display_loss: bool = False,
         mode_labels: list[str] | None = None,
-        display_type: str = "svg",
+        display_type: Literal["svg", "mpl"] = "svg",
     ) -> None:
         """
         Displays the current circuit with parameters set using either their

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -32,7 +32,7 @@ from lightworks.sdk.utils.exceptions import (
     ModeRangeError,
 )
 from lightworks.sdk.utils.param_unitary import ParameterizedUnitary
-from lightworks.sdk.visualisation import CAIROSVG_INSTALLED, display
+from lightworks.sdk.visualisation import display
 
 from .parameters import Parameter
 from .photonic_circuit_utils import (
@@ -531,8 +531,7 @@ class PhotonicCircuit:
                 should be placed within.
 
             svg (bool, optional) : Controls whether the figure is saved as an
-                svg (True) or png (False). png requires installing the cairosvg
-                module. Defaults to svg.
+                svg (True) or png (False). Defaults to svg.
 
             show_parameter_values (bool, optional) : Shows the values of
                 parameters instead of the associated labels if specified.
@@ -559,12 +558,6 @@ class PhotonicCircuit:
         if svg:
             figure.save_svg(p)
         else:
-            if not CAIROSVG_INSTALLED:
-                raise ModuleNotFoundError(
-                    "cairosvg module is required to save circuit figures as a "
-                    "png. The best way to install this dependency is with 'pip"
-                    " install drawsvg[raster]'."
-                )
             figure.set_pixel_scale(5)
             figure.save_png(str(p))
 

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Literal, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-from IPython import display
+from IPython import display as ipy_display
 from numpy.typing import NDArray
 
 from lightworks.sdk.utils.exceptions import (
@@ -31,7 +31,7 @@ from lightworks.sdk.utils.exceptions import (
     ModeRangeError,
 )
 from lightworks.sdk.utils.param_unitary import ParameterizedUnitary
-from lightworks.sdk.visualisation import Display
+from lightworks.sdk.visualisation import display
 
 from .parameters import Parameter
 from .photonic_circuit_utils import (
@@ -499,7 +499,7 @@ class PhotonicCircuit:
                 Should either be 'svg' or 'mpl', defaults to 'svg'.
 
         """
-        return_ = Display(
+        return_ = display(
             self,
             display_loss=display_loss,
             mode_labels=mode_labels,
@@ -509,7 +509,7 @@ class PhotonicCircuit:
         if display_type == "mpl":
             plt.show()
         elif display_type == "svg":
-            display.display(return_)
+            ipy_display.display(return_)
 
     def get_all_params(self) -> list[Parameter[Any]]:
         """

--- a/lightworks/sdk/utils/exceptions.py
+++ b/lightworks/sdk/utils/exceptions.py
@@ -117,3 +117,9 @@ class SamplerError(LightworksError):
     """
     Specific error in the Sampler objects.
     """
+
+
+class LightworksDependencyError(LightworksError):
+    """
+    For errors relating to a dependency of lightworks.
+    """

--- a/lightworks/sdk/visualisation/__init__.py
+++ b/lightworks/sdk/visualisation/__init__.py
@@ -13,9 +13,3 @@
 # limitations under the License.
 
 from .display_main import display
-
-CAIROSVG_INSTALLED = True
-try:
-    import cairosvg
-except ModuleNotFoundError:
-    CAIROSVG_INSTALLED = False

--- a/lightworks/sdk/visualisation/__init__.py
+++ b/lightworks/sdk/visualisation/__init__.py
@@ -13,3 +13,9 @@
 # limitations under the License.
 
 from .display_main import display
+
+CAIROSVG_INSTALLED = True
+try:
+    import cairosvg
+except ModuleNotFoundError:
+    CAIROSVG_INSTALLED = False

--- a/lightworks/sdk/visualisation/__init__.py
+++ b/lightworks/sdk/visualisation/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .display import Display
+from .display_main import display

--- a/lightworks/sdk/visualisation/display.py
+++ b/lightworks/sdk/visualisation/display.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import drawsvg
 import matplotlib.figure
@@ -27,12 +27,32 @@ if TYPE_CHECKING:
     from lightworks.sdk.circuit import PhotonicCircuit
 
 
+@overload
+def Display(
+    circuit: "PhotonicCircuit",
+    display_loss: bool = ...,
+    mode_labels: list[str] | None = ...,
+    display_type: Literal["svg"] = ...,
+    show_parameter_values: bool = ...,
+) -> drawsvg.Drawing: ...
+
+
+@overload
+def Display(
+    circuit: "PhotonicCircuit",
+    display_loss: bool = ...,
+    mode_labels: list[str] | None = ...,
+    display_type: Literal["mpl"] = ...,
+    show_parameter_values: bool = ...,
+) -> tuple[matplotlib.figure.Figure, plt.Axes]: ...
+
+
 # Display function to interact with relevant classes
 def Display(  # noqa: N802
     circuit: "PhotonicCircuit",
     display_loss: bool = False,
     mode_labels: list[str] | None = None,
-    display_type: str = "svg",
+    display_type: Literal["svg", "mpl"] = "svg",
     show_parameter_values: bool = False,
 ) -> tuple[matplotlib.figure.Figure, plt.Axes] | drawsvg.Drawing:
     """
@@ -71,8 +91,7 @@ def Display(  # noqa: N802
         disp = DrawCircuitMPL(
             circuit, display_loss, mode_labels, show_parameter_values
         )
-        fig, ax = disp.draw()
-        return (fig, ax)
+        return disp.draw()
     if display_type == "svg":
         disp_svg = DrawCircuitSVG(
             circuit, display_loss, mode_labels, show_parameter_values

--- a/lightworks/sdk/visualisation/display_main.py
+++ b/lightworks/sdk/visualisation/display_main.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 @overload
-def Display(
+def display(
     circuit: "PhotonicCircuit",
     display_loss: bool = ...,
     mode_labels: list[str] | None = ...,
@@ -38,7 +38,7 @@ def Display(
 
 
 @overload
-def Display(
+def display(
     circuit: "PhotonicCircuit",
     display_loss: bool = ...,
     mode_labels: list[str] | None = ...,
@@ -47,8 +47,8 @@ def Display(
 ) -> tuple[matplotlib.figure.Figure, plt.Axes]: ...
 
 
-# Display function to interact with relevant classes
-def Display(  # noqa: N802
+# display function to interact with relevant classes
+def display(
     circuit: "PhotonicCircuit",
     display_loss: bool = False,
     mode_labels: list[str] | None = None,
@@ -56,7 +56,7 @@ def Display(  # noqa: N802
     show_parameter_values: bool = False,
 ) -> tuple[matplotlib.figure.Figure, plt.Axes] | drawsvg.Drawing:
     """
-    Used to Display a circuit from lightworks in the chosen format.
+    Used to display a circuit from lightworks in the chosen format.
 
     Args:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pandas-stubs
 numpy>=1.24.3
 multimethod>=1.11.2
 qiskit[visualization]>=1.1.0
-drawsvg[raster]>=2.3.0
+drawsvg>=2.3.0
 sympy>=1.12.0
 pyarrow
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pandas-stubs
 numpy>=1.24.3
 multimethod>=1.11.2
 qiskit[visualization]>=1.1.0
-drawsvg>=2.3.0
+drawsvg[raster]>=2.3.0
 sympy>=1.12.0
 pyarrow
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ numpy>=1.24.3
 multimethod>=1.11.2
 qiskit[visualization]>=1.1.0
 drawsvg>=2.3.0
+CairoSVG>=2.8.0
 sympy>=1.12.0
 pyarrow
 ipython

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "numpy>=1.24.3",
         "multimethod>=1.11.2",
         "drawsvg>=2.3.0",
+        "CairoSVG>=2.8.0",
         "sympy>=1.12.0",
         "pyarrow",
         "ipython",

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -1067,6 +1067,8 @@ class TestCircuit:
             ("test.png", True),
             ("tests/test.svg", True),
             ("tests\\test.svg", True),
+            ("test", False),
+            ("test.png", False),
         ],
     )
     def test_circuit_saving(self, path, svg):

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from random import randint, random, seed
 
 import pytest
@@ -1057,6 +1058,37 @@ class TestCircuit:
         assert all(
             isinstance(c, Component) for c in circuit._get_circuit_spec()
         )
+
+    @pytest.mark.parametrize(
+        ("path", "svg"),
+        [
+            ("test", True),
+            ("test.svg", True),
+            ("test.png", True),
+            ("tests/test.svg", True),
+            ("tests\\test.svg", True),
+            ("test", False),
+            ("test.png", False),
+        ],
+    )
+    def test_circuit_saving(self, path, svg):
+        """
+        Checks that a figure can be created for a range target paths.
+        """
+        circuit = PhotonicCircuit(6)
+        circuit.add(CNOT())
+        circuit.bs(0)
+        circuit.ps(0, Parameter(3, label="μ"))
+        circuit.loss(2, 0.5)
+        circuit.mode_swaps({0: 2, 2: 0})
+        circuit.barrier()
+        # Save circuit
+        circuit.save_figure(path, svg=svg)
+        # Check it exists
+        path = Path(path)
+        path = path.with_suffix(".svg") if svg else path.with_suffix(".png")
+        assert path.exists()
+        path.unlink()
 
 
 class TestUnitary:

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -1067,8 +1067,6 @@ class TestCircuit:
             ("test.png", True),
             ("tests/test.svg", True),
             ("tests\\test.svg", True),
-            ("test", False),
-            ("test.png", False),
         ],
     )
     def test_circuit_saving(self, path, svg):

--- a/tests/sdk/display_test.py
+++ b/tests/sdk/display_test.py
@@ -20,12 +20,12 @@ import numpy as np
 import pytest
 
 from lightworks import (
-    Display,
     DisplayError,
     Parameter,
     PhotonicCircuit,
     Unitary,
     convert,
+    display,
     random_unitary,
 )
 
@@ -122,7 +122,7 @@ class TestDisplay:
         processed without any exceptions arising.
         """
         try:
-            Display(self.circuit, display_loss=True)
+            display(self.circuit, display_loss=True)
         except:
             pytest.fail("Exception occurred during display operation.")
 
@@ -138,7 +138,7 @@ class TestDisplay:
         original_backend = mpl.get_backend()
         mpl.use("Agg")
         try:
-            Display(self.circuit, display_loss=True, display_type="mpl")
+            display(self.circuit, display_loss=True, display_type="mpl")
             plt.close()
         except:
             pytest.fail("Exception occurred during display operation.")
@@ -153,7 +153,7 @@ class TestDisplay:
         with pytest.raises(DisplayError):
             self.circuit.display(display_type="not_valid")
         with pytest.raises(DisplayError):
-            Display(self.circuit, display_type="not_valid")
+            display(self.circuit, display_type="not_valid")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.parametrize("display_type", ["svg", "mpl"])


### PR DESCRIPTION
# Summary

Implements the `save_figure` method to `PhotonicCircuit`, allowing the output from the visualization routine to be saved to a file. The same options as with display method can be used to modify the output plot.

This PR also switches the name of the `lightworks.Display` function to `lightworks.display`, so it is now more in line with Python standards - this method was not commonly advertised, and instead `PhotonicCircuit.display` is preferred, so this should not affect many users.

Type hinting was also improved when selecting the different methods which could be used for displaying a circuit.
