### PR TITLE
Sphinx workflow fail on warning

### DIFF
--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Build HTML
         run: | 
           cd docs/
-          make html SPHINXOPTS="--nitpicky --fail-on-warning"
+          make html SPHINXOPTS="--fail-on-warning"

--- a/.github/workflows/sphinx_deploy.yml
+++ b/.github/workflows/sphinx_deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build HTML
         run: | 
           cd docs/
-          make html SPHINXOPTS="--nitpicky --fail-on-warning"
+          make html SPHINXOPTS="--fail-on-warning"
       
       # Use ghp-import on build folder to export docs
       - name: Run ghp-import


### PR DESCRIPTION
# Summary

Adds the fail-on-warning flag to the sphinx build and deploy workflows so there fail on exit if any warning are raised during the process.