### PR TITLE
Docs typo & missing reference

### DIFF
--- a/docs/source/sdk/post_selection.rst
+++ b/docs/source/sdk/post_selection.rst
@@ -41,7 +41,7 @@ As mentioned, any combination of photon numbers and modes can be used, so all of
 .. code-block:: Python
 
     post_selection.add(2, 1) # Require measuring 1 photon on mode 2
-    post_selection.add(3, (1, 2)) # Require measuring 1 or 2 photons on mode 2
+    post_selection.add(3, (1, 2)) # Require measuring 1 or 2 photons on mode 3
     post_selection.add((4, 5, 6), (1, 2)) # Require measuring 1 or 2 photons across modes 4, 5 & 6
 
 .. note::

--- a/docs/source/sdk_reference/utils.rst
+++ b/docs/source/sdk_reference/utils.rst
@@ -1,25 +1,18 @@
 Utilities
 =========
 
-.. _random_unitary:
-
 .. autofunction:: lightworks.random_unitary
 
-.. _random_permutation:
-
 .. autofunction:: lightworks.random_permutation
-
-.. _conversion:
 
 .. autoclass:: lightworks.convert
     :members:
 
-.. _post_selection:
-
 .. autoclass:: lightworks.PostSelection
     :members:
 
-.. _post_selection_func:
-
 .. autoclass:: lightworks.PostSelectionFunction
+    :members:
+
+.. autoclass:: lightworks.sdk.utils.post_selection.Rule
     :members:


### PR DESCRIPTION
# Summary

Corrects a small typo in the docs and adds the Rule object for post-selection into the SDK reference.
