### PR TITLE
Copyright header update

### DIFF
--- a/.github/workflows/update_copyright.py
+++ b/.github/workflows/update_copyright.py
@@ -1,0 +1,21 @@
+import datetime
+import os
+
+current_year = f"{datetime.datetime.now(tz=datetime.UTC).year:04d}"
+
+for directory in ["lightworks", "docs", "tests"]:
+    for root, _, files in os.walk(f"{directory}"):
+        # Generate list of all python files in a directory
+        py_files = [f for f in files if f.endswith(".py")]
+        for f_name in py_files:
+            with open(root + "/" + f_name, encoding="utf-8") as f:
+                lines = f.readlines()
+            # Loop through all lines until the copyright one is found, then edit
+            # this and break the loop
+            for i, line in enumerate(lines):
+                if line.startswith("# Copyright"):
+                    lines[i] = line[:19] + current_year + line[23:]
+                    continue
+            # Write new python file
+            with open(root + "/" + f_name, "w", encoding="utf-8") as f:
+                f.writelines(lines)

--- a/lightworks/__init__.py
+++ b/lightworks/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/__settings.py
+++ b/lightworks/__settings.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/__version.py
+++ b/lightworks/__version.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/__init__.py
+++ b/lightworks/emulator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/backends/__init__.py
+++ b/lightworks/emulator/backends/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/backends/abc_backend.py
+++ b/lightworks/emulator/backends/abc_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/backends/backend.py
+++ b/lightworks/emulator/backends/backend.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/backends/caching.py
+++ b/lightworks/emulator/backends/caching.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/backends/fock_backend.py
+++ b/lightworks/emulator/backends/fock_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/backends/permanent.py
+++ b/lightworks/emulator/backends/permanent.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/backends/slos.py
+++ b/lightworks/emulator/backends/slos.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/components/__init__.py
+++ b/lightworks/emulator/components/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/components/detector.py
+++ b/lightworks/emulator/components/detector.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/components/source.py
+++ b/lightworks/emulator/components/source.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/simulation/__init__.py
+++ b/lightworks/emulator/simulation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/simulation/analyzer.py
+++ b/lightworks/emulator/simulation/analyzer.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/simulation/probability_distribution.py
+++ b/lightworks/emulator/simulation/probability_distribution.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/simulation/runner.py
+++ b/lightworks/emulator/simulation/runner.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/simulation/simulator.py
+++ b/lightworks/emulator/simulation/simulator.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/state/__init__.py
+++ b/lightworks/emulator/state/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/state/annotated_state.py
+++ b/lightworks/emulator/state/annotated_state.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/utils/__init__.py
+++ b/lightworks/emulator/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/utils/exceptions.py
+++ b/lightworks/emulator/utils/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/utils/sim.py
+++ b/lightworks/emulator/utils/sim.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/emulator/utils/state.py
+++ b/lightworks/emulator/utils/state.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/__init__.py
+++ b/lightworks/interferometers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/decomposition.py
+++ b/lightworks/interferometers/decomposition.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/dists/__init__.py
+++ b/lightworks/interferometers/dists/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/dists/constant.py
+++ b/lightworks/interferometers/dists/constant.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/dists/distribution.py
+++ b/lightworks/interferometers/dists/distribution.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/dists/gaussian.py
+++ b/lightworks/interferometers/dists/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/dists/top_hat.py
+++ b/lightworks/interferometers/dists/top_hat.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/dists/utils.py
+++ b/lightworks/interferometers/dists/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/error_model.py
+++ b/lightworks/interferometers/error_model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/interferometers/reck.py
+++ b/lightworks/interferometers/reck.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/qubit/__init__.py
+++ b/lightworks/qubit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/qubit/converter/__init__.py
+++ b/lightworks/qubit/converter/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/qubit/converter/qiskit_convert.py
+++ b/lightworks/qubit/converter/qiskit_convert.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/qubit/gates/__init__.py
+++ b/lightworks/qubit/gates/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/qubit/gates/single_qubit_gates.py
+++ b/lightworks/qubit/gates/single_qubit_gates.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/qubit/gates/three_qubit_gates.py
+++ b/lightworks/qubit/gates/three_qubit_gates.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/qubit/gates/two_qubit_gates.py
+++ b/lightworks/qubit/gates/two_qubit_gates.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/__init__.py
+++ b/lightworks/sdk/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/circuit/__init__.py
+++ b/lightworks/sdk/circuit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/circuit/parameters.py
+++ b/lightworks/sdk/circuit/parameters.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/circuit/photonic_circuit_utils.py
+++ b/lightworks/sdk/circuit/photonic_circuit_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/circuit/photonic_compiler.py
+++ b/lightworks/sdk/circuit/photonic_compiler.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/circuit/photonic_components.py
+++ b/lightworks/sdk/circuit/photonic_components.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/circuit/unitary.py
+++ b/lightworks/sdk/circuit/unitary.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/results/__init__.py
+++ b/lightworks/sdk/results/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/results/probability_distribution.py
+++ b/lightworks/sdk/results/probability_distribution.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/results/result.py
+++ b/lightworks/sdk/results/result.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/results/sampling_result.py
+++ b/lightworks/sdk/results/sampling_result.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/results/simulation_result.py
+++ b/lightworks/sdk/results/simulation_result.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/state/__init__.py
+++ b/lightworks/sdk/state/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/state/state.py
+++ b/lightworks/sdk/state/state.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/tasks/__init__.py
+++ b/lightworks/sdk/tasks/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/tasks/analyzer.py
+++ b/lightworks/sdk/tasks/analyzer.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/tasks/batch.py
+++ b/lightworks/sdk/tasks/batch.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/tasks/data.py
+++ b/lightworks/sdk/tasks/data.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/tasks/sampler.py
+++ b/lightworks/sdk/tasks/sampler.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/tasks/simulator.py
+++ b/lightworks/sdk/tasks/simulator.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/tasks/task.py
+++ b/lightworks/sdk/tasks/task.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/__init__.py
+++ b/lightworks/sdk/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/conversion.py
+++ b/lightworks/sdk/utils/conversion.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/exceptions.py
+++ b/lightworks/sdk/utils/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/heralding.py
+++ b/lightworks/sdk/utils/heralding.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/matrix.py
+++ b/lightworks/sdk/utils/matrix.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/param_unitary.py
+++ b/lightworks/sdk/utils/param_unitary.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Aegiq Ltd.
+# Copyright 2025 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/permutation.py
+++ b/lightworks/sdk/utils/permutation.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/post_selection.py
+++ b/lightworks/sdk/utils/post_selection.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/random.py
+++ b/lightworks/sdk/utils/random.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/utils/state.py
+++ b/lightworks/sdk/utils/state.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/visualisation/__init__.py
+++ b/lightworks/sdk/visualisation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/visualisation/display_main.py
+++ b/lightworks/sdk/visualisation/display_main.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/visualisation/display_utils.py
+++ b/lightworks/sdk/visualisation/display_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/visualisation/draw_circuit_mpl.py
+++ b/lightworks/sdk/visualisation/draw_circuit_mpl.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/visualisation/draw_circuit_svg.py
+++ b/lightworks/sdk/visualisation/draw_circuit_svg.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/sdk/visualisation/draw_specs.py
+++ b/lightworks/sdk/visualisation/draw_specs.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/__init__.py
+++ b/lightworks/tomography/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/experiments.py
+++ b/lightworks/tomography/experiments.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/gate_fidelity.py
+++ b/lightworks/tomography/gate_fidelity.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/mappings.py
+++ b/lightworks/tomography/mappings.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/process_tomography.py
+++ b/lightworks/tomography/process_tomography.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/process_tomography_li.py
+++ b/lightworks/tomography/process_tomography_li.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/process_tomography_mle.py
+++ b/lightworks/tomography/process_tomography_mle.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/state_tomography.py
+++ b/lightworks/tomography/state_tomography.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/tomography.py
+++ b/lightworks/tomography/tomography.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lightworks/tomography/utils.py
+++ b/lightworks/tomography/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/__init__.py
+++ b/tests/emulator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/analyzer_test.py
+++ b/tests/emulator/analyzer_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/annotatedstate_test.py
+++ b/tests/emulator/annotatedstate_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/backend_test.py
+++ b/tests/emulator/backend_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/cnot_test.py
+++ b/tests/emulator/cnot_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/detector_test.py
+++ b/tests/emulator/detector_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/sampler_test.py
+++ b/tests/emulator/sampler_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/simulator_test.py
+++ b/tests/emulator/simulator_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/emulator/source_test.py
+++ b/tests/emulator/source_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/interferometers/__init__.py
+++ b/tests/interferometers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/interferometers/decomposition_test.py
+++ b/tests/interferometers/decomposition_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/interferometers/distribution_test.py
+++ b/tests/interferometers/distribution_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/interferometers/error_model_test.py
+++ b/tests/interferometers/error_model_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/interferometers/interferometer_test.py
+++ b/tests/interferometers/interferometer_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/qubit/__init__.py
+++ b/tests/qubit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/qubit/converter_test.py
+++ b/tests/qubit/converter_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/qubit/gate_test.py
+++ b/tests/qubit/gate_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/__init__.py
+++ b/tests/sdk/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/batch_test.py
+++ b/tests/sdk/batch_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/compiledcircuit_test.py
+++ b/tests/sdk/compiledcircuit_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/display_test.py
+++ b/tests/sdk/display_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/parameter_test.py
+++ b/tests/sdk/parameter_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/result_test.py
+++ b/tests/sdk/result_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/state_test.py
+++ b/tests/sdk/state_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sdk/util_test.py
+++ b/tests/sdk/util_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/tomography/__init__.py
+++ b/tests/tomography/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/tomography/process_test.py
+++ b/tests/tomography/process_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/tomography/state_test.py
+++ b/tests/tomography/state_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/tomography/util_test.py
+++ b/tests/tomography/util_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Aegiq Ltd.
+# Copyright 2024 - 2025 Aegiq Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Summary

Updates the year in copyright headers to be a range and sets end of range to be the current year.

A script has also been added in the .github folder which can be run to update this.
