### PR TITLE
Direct backend call

### DIFF
--- a/docs/source/emulator/backend.rst
+++ b/docs/source/emulator/backend.rst
@@ -43,6 +43,12 @@ The task can then be run against the backend with the ``run`` method, this will 
 
     results = backend.run(sim)
 
+Alternatively, the run method can be excluded and a function call made directly to the backend, so the equivalent code to above would be: 
+
+.. code-block:: Python
+
+    results = backend(sim)
+
 The results can then be viewed using one of the built-in methods, such as plot.
 
 .. code-block:: Python

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -75,11 +75,15 @@ For this initial simulation, we will choose to use the :class:`Sampler <lightwor
     n_samples = 10000
     sampler = lw.Sampler(circuit, input_state, n_samples, random_seed = 1)
 
-A backend from the emulator then needs to be selected to run the sampler task on. In this case the permanent backend is chosen, more information about this can be found in :doc:`emulator/backend`. The task is then executed using this backend with ``run``.
+A backend from the emulator then needs to be selected to run the sampler task on. In this case the permanent backend is chosen, more information about this can be found in :doc:`emulator/backend`. The task is then executed using this backend with ``run`` or by directly calling the backend as a function, both examples are shown below.
 
 .. code-block:: Python
 
     backend = emulator.Backend("permanent")
+
+    # Run method
+    results = backend.run(sampler)
+    # Direct call
     results = backend.run(sampler)
 
 This produces a :doc:`sdk_reference/results/sampling_result` object, we can quickly view the contents of this using the print statement.

--- a/lightworks/emulator/backends/backend.py
+++ b/lightworks/emulator/backends/backend.py
@@ -43,6 +43,18 @@ class Backend:
         self.backend = backend
 
     @overload
+    def __call__(self, task: Task) -> Result[Any, Any]: ...
+
+    @overload
+    def __call__(self, task: Batch) -> list[Result[Any, Any]]: ...
+
+    def __call__(
+        self, task: Task | Batch
+    ) -> Result[Any, Any] | list[Result[Any, Any]]:
+        """Runs the provided task on the current backend."""
+        return self.run(task)
+
+    @overload
     def run(self, task: Task) -> Result[Any, Any]: ...
 
     @overload

--- a/tests/emulator/backend_test.py
+++ b/tests/emulator/backend_test.py
@@ -111,6 +111,23 @@ class TestBackend:
         backend = Backend("permanent")
         assert "permanent" in repr(backend)
 
+    def test_backend_call(self):
+        """
+        Checks that a backend can be called directly by providing a target task.
+        """
+        backend = Backend("permanent")
+        sim = Simulator(Unitary(random_unitary(4)), State([1, 0, 1, 0]))
+        backend(sim)
+
+    def test_backend_call_equivalance(self):
+        """
+        Checks that a backend can be called directly and this produces
+        equivalent results to run.
+        """
+        backend = Backend("permanent")
+        sim = Simulator(Unitary(random_unitary(4)), State([1, 0, 1, 0]))
+        assert backend.run(sim) == backend(sim)
+
 
 class TestPermanent:
     """


### PR DESCRIPTION
# Summary

Adds the ability for defined backends to be used as a function that can be called, bypassing inclusion of the run method. So, for example, `backend.run(task)` could instead become `backend(task)`. This is completely optional and is primarily just added for convenience.

Associated tests and updates to the documentation are also included. 