### PR TITLE
Sampling optimisation

### DIFF
--- a/lightworks/emulator/backends/fock_backend.py
+++ b/lightworks/emulator/backends/fock_backend.py
@@ -67,7 +67,7 @@ class FockBackend(EmulatorBackend):
         cached_results = self._check_cache(data)
         if cached_results is not None:
             runner.probability_distribution = cached_results["pdist"]
-            runner.full_to_heralded = cached_results["full_to_herald"]
+            runner.herald_cache = cached_results["herald_cache"]
             task._probability_distribution = ProbabilityDistribution(
                 cached_results["pdist"]
             )
@@ -77,7 +77,7 @@ class FockBackend(EmulatorBackend):
             )
             results = {
                 "pdist": runner.probability_distribution,
-                "full_to_herald": runner.full_to_heralded,
+                "herald_cache": runner.herald_cache,
             }
             self._add_to_cache(data, results)
         return runner.run()

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -356,7 +356,7 @@ class _HeraldCache:
     """
 
     def __init__(self, herald_modes: list[int]) -> None:
-        self.cache = {}
+        self.cache: dict[State, State] = {}
         self.herald_modes = list(herald_modes)
 
     def __getitem__(self, state: State) -> State:

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -100,13 +100,7 @@ class SamplerRunner(RunnerABC):
         # Assign calculated distribution to attribute
         self.probability_distribution = pdist
         herald_modes = list(self.data.circuit.heralds.output.keys())
-        self.herald_cache = _HeraldCache(
-            {
-                s: State(remove_heralds_from_state(s, herald_modes))
-                for s in pdist
-            },
-            herald_modes,
-        )
+        self.herald_cache = _HeraldCache(herald_modes)
         return pdist
 
     def run(self) -> SamplingResult:
@@ -340,7 +334,8 @@ class SamplerRunner(RunnerABC):
         normalize: bool = False,
     ) -> dict[State, int]:
         """
-        Takes a computed probability distribution and
+        Takes a computed probability distribution and generates the request
+        number of samples, returning this as a dictionary of states and counts.
         """
         # Re-normalise distribution probabilities
         mapping = dict(enumerate(distribution))
@@ -360,10 +355,8 @@ class _HeraldCache:
     heralded modes removed.
     """
 
-    def __init__(
-        self, initial: dict[State, State], herald_modes: list[int]
-    ) -> None:
-        self.cache = initial
+    def __init__(self, herald_modes: list[int]) -> None:
+        self.cache = {}
         self.herald_modes = list(herald_modes)
 
     def __getitem__(self, state: State) -> State:

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -347,7 +347,7 @@ class SamplerRunner(RunnerABC):
         n_samples: int,
         seed: int | None,
         normalize: bool = False,
-    ) -> SamplingResult:
+    ) -> dict[State, int]:
         """
         Takes a computed probability distribution and
         """


### PR DESCRIPTION
# Summary

Implements some optimisation to the state sampling routines, in which integers are sampled instead of the states themselves. For the output sampling mode this was tested to yield a 2-10x speedup in sampling rates, and for the input sampling mode it was 1-2x (due to differing operation principles). Note, this is a speedup in sampling from a calculated distribution, rather than in calculation of the distribution itself. 

Run time of the full unit test suite has been approximately halved through these improvements.