### PR TITLE
Remove basis generation from runners

### DIFF
--- a/lightworks/emulator/backends/fock_backend.py
+++ b/lightworks/emulator/backends/fock_backend.py
@@ -53,12 +53,16 @@ class FockBackend(EmulatorBackend):
     @run.register
     def run_simulator(self, task: Simulator) -> SimulationResult:
         data = task._generate_task()
-        return SimulatorRunner(data, self.probability_amplitude).run()
+        return SimulatorRunner(
+            data, self.probability_amplitude, self.state_generator
+        ).run()
 
     @run.register
     def run_analyzer(self, task: Analyzer) -> SimulationResult:
         data = task._generate_task()
-        return AnalyzerRunner(data, self.probability).run()
+        return AnalyzerRunner(
+            data, self.probability, self.state_generator
+        ).run()
 
     @run.register
     def run_sampler(self, task: Sampler) -> SamplingResult:
@@ -84,6 +88,12 @@ class FockBackend(EmulatorBackend):
 
     # Below defaults are defined for all possible methods in case they are
     # called without being implemented. This shouldn't normally happen.
+
+    def state_generator(self, n_modes: int, n_photons: int) -> list[list[int]]:
+        raise BackendError(
+            "The required state generation function is not defined by this "
+            "backend."
+        )
 
     def probability_amplitude(
         self,

--- a/lightworks/emulator/backends/permanent.py
+++ b/lightworks/emulator/backends/permanent.py
@@ -45,7 +45,8 @@ class PermanentBackend(FockBackend):
 
     def state_generator(self, n_modes: int, n_photons: int) -> list[list[int]]:
         """
-        Generates all possible photonic states.
+        Generates all possible photonic states for a given number of modes and
+        photons.
         """
         return fock_basis(n_modes, n_photons)
 

--- a/lightworks/emulator/backends/permanent.py
+++ b/lightworks/emulator/backends/permanent.py
@@ -43,6 +43,12 @@ class PermanentBackend(FockBackend):
         """Returns backends which are compatible with the backend."""
         return ("Sampler", "Analyzer", "Simulator")
 
+    def state_generator(self, n_modes: int, n_photons: int) -> list[list[int]]:
+        """
+        Generates all possible photonic states.
+        """
+        return fock_basis(n_modes, n_photons)
+
     def probability_amplitude(
         self,
         unitary: NDArray[np.complex128],

--- a/lightworks/emulator/simulation/analyzer.py
+++ b/lightworks/emulator/simulation/analyzer.py
@@ -54,8 +54,8 @@ class AnalyzerRunner(RunnerABC):
         state_generator: Callable[[int, int], list[list[int]]],
     ) -> None:
         self.data = data
-        self.func = probability_function
-        self.s_gen = state_generator
+        self.probability_function = probability_function
+        self.state_generator = state_generator
 
     def run(self) -> SimulationResult:
         """
@@ -120,13 +120,13 @@ class AnalyzerRunner(RunnerABC):
             for j, outs in enumerate(full_outputs):
                 # No loss case
                 if not self.data.circuit.loss_modes:
-                    probs[i, j] += self.func(
+                    probs[i, j] += self.probability_function(
                         self.data.circuit.U_full, ins, outs
                     )
                 # Lossy case
                 # Photon number preserved
                 elif sum(ins) == sum(outs):
-                    probs[i, j] += self.func(
+                    probs[i, j] += self.probability_function(
                         self.data.circuit.U_full,
                         ins,
                         outs + [0] * self.data.circuit.loss_modes,
@@ -141,12 +141,12 @@ class AnalyzerRunner(RunnerABC):
                             "Output photon number larger than input number."
                         )
                     # Find loss states and find probability of each
-                    loss_states = self.s_gen(
+                    loss_states = self.state_generator(
                         self.data.circuit.loss_modes, n_loss
                     )
                     for ls in loss_states:
                         fs = outs + ls
-                        probs[i, j] += self.func(
+                        probs[i, j] += self.probability_function(
                             self.data.circuit.U_full, ins, fs
                         )
 
@@ -196,12 +196,12 @@ class AnalyzerRunner(RunnerABC):
         """
         # Get all possible outputs for the non-herald modes
         if not self.data.circuit.loss_modes:
-            outputs = self.s_gen(n_modes, n_photons)
+            outputs = self.state_generator(n_modes, n_photons)
         # Combine all n < n_in for lossy case
         else:
             outputs = []
             for n in range(n_photons + 1):
-                outputs += self.s_gen(n_modes, n)
+                outputs += self.state_generator(n_modes, n)
         # Filter outputs according to post selection and add heralded photons
         filtered_outputs = []
         full_outputs = []

--- a/lightworks/emulator/simulation/analyzer.py
+++ b/lightworks/emulator/simulation/analyzer.py
@@ -18,7 +18,6 @@ import numpy as np
 from numpy.typing import NDArray
 
 from lightworks.emulator.utils.sim import check_photon_numbers
-from lightworks.emulator.utils.state import fock_basis
 from lightworks.sdk.results import SimulationResult
 from lightworks.sdk.state import State
 from lightworks.sdk.tasks import AnalyzerTask
@@ -41,6 +40,9 @@ class AnalyzerRunner(RunnerABC):
         probability_function (Callable) : Function for calculating probability
             of transition between an input and output for a given unitary.
 
+        state_generator (Callable) : A function for generating the basis states
+            for a given number of modes and photons.
+
     """
 
     def __init__(
@@ -49,9 +51,11 @@ class AnalyzerRunner(RunnerABC):
         probability_function: Callable[
             [NDArray[np.complex128], list[int], list[int]], float
         ],
+        state_generator: Callable[[int, int], list[list[int]]],
     ) -> None:
         self.data = data
         self.func = probability_function
+        self.s_gen = state_generator
 
     def run(self) -> SimulationResult:
         """
@@ -137,7 +141,7 @@ class AnalyzerRunner(RunnerABC):
                             "Output photon number larger than input number."
                         )
                     # Find loss states and find probability of each
-                    loss_states = fock_basis(
+                    loss_states = self.s_gen(
                         self.data.circuit.loss_modes, n_loss
                     )
                     for ls in loss_states:
@@ -192,12 +196,12 @@ class AnalyzerRunner(RunnerABC):
         """
         # Get all possible outputs for the non-herald modes
         if not self.data.circuit.loss_modes:
-            outputs = fock_basis(n_modes, n_photons)
+            outputs = self.s_gen(n_modes, n_photons)
         # Combine all n < n_in for lossy case
         else:
             outputs = []
             for n in range(n_photons + 1):
-                outputs += fock_basis(n_modes, n)
+                outputs += self.s_gen(n_modes, n)
         # Filter outputs according to post selection and add heralded photons
         filtered_outputs = []
         full_outputs = []

--- a/lightworks/emulator/simulation/sampler.py
+++ b/lightworks/emulator/simulation/sampler.py
@@ -73,7 +73,7 @@ class SamplerRunner(RunnerABC):
         self.detector = (
             Detector() if self.data.detector is None else self.data.detector
         )
-        self.func = pdist_function
+        self.pdist_function = pdist_function
 
     def distribution_calculator(self) -> dict[State, float]:
         """
@@ -93,7 +93,7 @@ class SamplerRunner(RunnerABC):
         # Then build with source
         all_inputs = self.source._build_statistics(input_state)
         # And find probability distribution
-        pdist = pdist_calc(self.data.circuit, all_inputs, self.func)
+        pdist = pdist_calc(self.data.circuit, all_inputs, self.pdist_function)
         # Special case to catch an empty distribution
         if not pdist:
             pdist = {State([0] * self.data.circuit.n_modes): 1}

--- a/lightworks/emulator/simulation/simulator.py
+++ b/lightworks/emulator/simulation/simulator.py
@@ -52,8 +52,8 @@ class SimulatorRunner(RunnerABC):
         state_generator: Callable[[int, int], list[list[int]]],
     ) -> None:
         self.data = data
-        self.func = amplitude_function
-        self.s_gen = state_generator
+        self.amplitude_function = amplitude_function
+        self.state_generator = state_generator
 
     def run(self) -> SimulationResult:
         """
@@ -76,7 +76,7 @@ class SimulatorRunner(RunnerABC):
             check_photon_numbers(self.data.inputs, target_n - in_heralds_n)
             outputs = [
                 State(s)
-                for s in self.s_gen(
+                for s in self.state_generator(
                     self.data.circuit.input_modes, target_n - out_heralds_n
                 )
             ]
@@ -99,7 +99,7 @@ class SimulatorRunner(RunnerABC):
             in_state = add_heralds_to_state(ins, in_heralds)
             in_state += [0] * self.data.circuit.loss_modes
             for j, outs in enumerate(full_outputs):
-                amplitudes[i, j] = self.func(
+                amplitudes[i, j] = self.amplitude_function(
                     self.data.circuit.U_full, in_state, outs
                 )
         # Return results and corresponding states as dictionary

--- a/lightworks/emulator/simulation/simulator.py
+++ b/lightworks/emulator/simulation/simulator.py
@@ -18,7 +18,6 @@ import numpy as np
 from numpy.typing import NDArray
 
 from lightworks.emulator.utils.sim import check_photon_numbers
-from lightworks.emulator.utils.state import fock_basis
 from lightworks.sdk.results import SimulationResult
 from lightworks.sdk.state import State
 from lightworks.sdk.tasks import SimulatorTask
@@ -39,6 +38,9 @@ class SimulatorRunner(RunnerABC):
         amplitude_function (Callable) : Function for calculating probability
             amplitudes between an input and output for a given unitary.
 
+        state_generator (Callable) : A function for generating the basis states
+            for a given number of modes and photons.
+
     """
 
     def __init__(
@@ -47,9 +49,11 @@ class SimulatorRunner(RunnerABC):
         amplitude_function: Callable[
             [NDArray[np.complex128], list[int], list[int]], complex
         ],
+        state_generator: Callable[[int, int], list[list[int]]],
     ) -> None:
         self.data = data
         self.func = amplitude_function
+        self.s_gen = state_generator
 
     def run(self) -> SimulationResult:
         """
@@ -72,7 +76,7 @@ class SimulatorRunner(RunnerABC):
             check_photon_numbers(self.data.inputs, target_n - in_heralds_n)
             outputs = [
                 State(s)
-                for s in fock_basis(
+                for s in self.s_gen(
                     self.data.circuit.input_modes, target_n - out_heralds_n
                 )
             ]

--- a/lightworks/emulator/utils/state.py
+++ b/lightworks/emulator/utils/state.py
@@ -19,9 +19,9 @@ Script to store various useful functions for the simulation aspect of the code.
 from collections.abc import Iterable
 
 
-def fock_basis(N: int, n: int) -> list[list[int]]:  # noqa: N803
+def fock_basis(n_modes: int, n_photons: int) -> list[list[int]]:
     """Returns the Fock basis for n photons in N modes."""
-    return list(_sums(N, n))
+    return list(_sums(n_modes, n_photons))
 
 
 def _sums(length: int, total_sum: int) -> Iterable[list[int]]:


### PR DESCRIPTION
# Summary

Removes the fock basis generation function from the task runners and instead defines these within a backend. This is intended to give additionally flexibility for future updates, and has no effect on users of Lightworks.
