### PR TITLE
Circuit equivalence

### DIFF
--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -119,6 +119,8 @@ class PhotonicCircuit:
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, PhotonicCircuit):
             return False
+        if self.n_modes != value.n_modes:
+            return False
         u1, u2 = self.U_full, value.U_full
         if u1.shape != u2.shape:
             return False

--- a/lightworks/sdk/circuit/photonic_circuit.py
+++ b/lightworks/sdk/circuit/photonic_circuit.py
@@ -113,6 +113,17 @@ class PhotonicCircuit:
     def __repr__(self) -> str:
         return f"lightworks.PhotonicCircuit({self.n_modes})"
 
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, PhotonicCircuit):
+            return False
+        u1, u2 = self.U_full, value.U_full
+        if u1.shape != u2.shape:
+            return False
+        return np.allclose(u1, u2, rtol=0, atol=1e-8)
+
     @property
     def U(self) -> NDArray[np.complex128]:  # noqa: N802
         """

--- a/tests/sdk/circuit_test.py
+++ b/tests/sdk/circuit_test.py
@@ -1106,6 +1106,63 @@ class TestCircuit:
             assert path.exists()
             path.unlink()
 
+    def test_circuit_equivalence(self):
+        """
+        Checks that the equals comparison between two circuits returns true when
+        they are the same.
+        """
+        # Define two circuits, changing the order in which components are added
+        c1 = PhotonicCircuit(5)
+        c1.bs(0, reflectivity=0.4)
+        c1.bs(3, reflectivity=0.55)
+        c1.ps(2, 0.531, loss=0.3)
+        c2 = PhotonicCircuit(5)
+        c2.ps(2, 0.531, loss=0.3)
+        c2.bs(3, reflectivity=0.55)
+        c2.bs(0, reflectivity=0.4)
+        # Check equivalence
+        assert c1 == c2
+
+    def test_circuit_non_equivalence(self):
+        """
+        Checks that the equals comparison between two circuits returns false
+        when the unitary differs.
+        """
+        # Define two circuits, changing the order in which components are added
+        c1 = PhotonicCircuit(5)
+        c1.bs(0, reflectivity=0.4)
+        c1.bs(3, reflectivity=0.55)
+        c1.ps(2, 0.531, loss=0.3)
+        c2 = PhotonicCircuit(5)
+        c2.ps(2, 0.2, loss=0.3)
+        c2.bs(3, reflectivity=0.3)
+        c2.bs(0, reflectivity=0.45)
+        # Check equivalence
+        assert c1 != c2
+
+    def test_circuit_non_equivalence_modes(self):
+        """
+        Checks that the equals comparison between two circuits returns false
+        when the number of modes is different.
+        """
+        # Define two circuits, changing the order in which components are added
+        c1 = PhotonicCircuit(5)
+        c2 = PhotonicCircuit(2)
+        # Check equivalence
+        assert c1 != c2
+
+    def test_circuit_non_equivalence_loss_modes(self):
+        """
+        Checks that the equals comparison between two circuits returns false
+        when the number of loss modes is different.
+        """
+        # Define two circuits, changing the order in which components are added
+        c1 = PhotonicCircuit(5)
+        c2 = PhotonicCircuit(5)
+        c2.loss(0, 0.5)
+        # Check equivalence
+        assert c1 != c2
+
 
 class TestUnitary:
     """


### PR DESCRIPTION
# Summary

Adds the __eq__ method to `PhotonicCircuit` allowing for quick checks as to whether the unitary matrices implemented by two circuits are equivalent (up to a numerical precision of 1e-8). 