### PR TITLE
Qiskit converter barrier support

### DIFF
--- a/lightworks/qubit/converter/converter.py
+++ b/lightworks/qubit/converter/converter.py
@@ -185,3 +185,10 @@ class Converter:
         else:
             msg = f"Unsupported gate '{gate}' included in circuit."
             raise ValueError(msg)
+
+    def _add_barrier(self, circuit: PhotonicCircuit, qubits: list[int]) -> None:
+        """
+        Adds a barrier to the circuit on the provided qubits.
+        """
+        modes = [self._modes[q][i] for q in qubits for i in range(2)]
+        circuit.barrier(modes)

--- a/lightworks/qubit/converter/qiskit_convert.py
+++ b/lightworks/qubit/converter/qiskit_convert.py
@@ -35,6 +35,7 @@ ALLOWED_GATES = [
     *ROTATION_GATES_MAP,
     *TWO_QUBIT_GATES_MAP,
     *THREE_QUBIT_GATES_MAP,
+    "barrier",
     "u",
 ]
 
@@ -130,8 +131,11 @@ class QiskitConverter(Converter):
             if gate not in ALLOWED_GATES:
                 msg = f"Unsupported gate '{gate}' included in circuit."
                 raise ValueError(msg)
+            # First catch barriers
+            if gate == "barrier":
+                self._add_barrier(circuit, qubits)
             # Single Qubit Gates
-            if len(qubits) == 1:
+            elif len(qubits) == 1:
                 if gate == "u":
                     self._add_single_qubit_unitary(
                         circuit, inst.params, qubits[0]

--- a/lightworks/qubit/converter/utils.py
+++ b/lightworks/qubit/converter/utils.py
@@ -90,7 +90,10 @@ def post_selection_analyzer(
     # First extract all qubit data from the circuit
     gate_qubits: list[list[int] | None] = []
     for inst in qc.data:
-        if inst.operation.num_qubits >= 2:
+        if inst.operation.num_qubits >= 2 and inst.operation.name not in {
+            "barrier",
+            "swap",
+        }:
             gate_qubits.append(
                 [
                     inst.qubits[i]._index


### PR DESCRIPTION
# Summary

Adds support for barriers included within a qiskit circuit, meaning these are now carried over to the created Lightworks circuit.
