### PR TITLE
Checkout action update + Readme badge fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -59,7 +59,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       
       - name: Download docs artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -18,7 +18,7 @@ jobs:
         id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -39,7 +39,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         token: ${{ secrets.PAT }}
         ref: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     
     # Runs for each version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Tests](https://github.com/Aegiq/lightworks/actions/workflows/tests.yml/badge.svg?event=push)](https://github.com/Aegiq/lightworks/actions/workflows/tests.yml)
-[![Docs](https://github.com/Aegiq/lightworks/actions/workflows/sphinx_deploy.yml/badge.svg?event=push)](https://github.com/Aegiq/lightworks/actions/workflows/sphinx_deploy.yml)
+[![Docs](https://github.com/Aegiq/lightworks/actions/workflows/docs.yml/badge.svg?event=push)](https://github.com/Aegiq/lightworks/actions/workflows/docs.yml)
 [![Pyversions](https://img.shields.io/pypi/pyversions/lightworks.svg?style=plastic)](https://pypi.org/project/lightworks/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14925692.svg)](https://doi.org/10.5281/zenodo.14925692)
 


### PR DESCRIPTION
# Summary

Updates the checkout action used in github actions to v5, removing warnings produced by v4. Also fixes the docs badge in the readme after this was broken when changing the workflow name.
